### PR TITLE
Fixed a bug where the IDE would abort a Fast Execute early.

### DIFF
--- a/js/repl.js
+++ b/js/repl.js
@@ -126,7 +126,10 @@ class ReplJS{
             var tempLines = this.COLLECTED_DATA.split('\r\n');
 
             for(var i=0; i<tempLines.length; i++){
-                if(tempLines[i] == "OK" || tempLines[i] == ">"){
+                // Sometimes the OK response gets mixed with the prompt, e.g:
+                //    0: "raw REPL; CTRL-B to exit"
+                //    1: ">OK"
+                if(tempLines[i] == "OK" || tempLines[i] == ">OK" || tempLines[i] == ">"){
                     return;
                 }
             }


### PR DESCRIPTION
This would show in the IDE Console like this:
```
MicroPython v1.19.1 on 2022-06-18; Raspberry Pi Pico with RP2040
Type "help()" for more information.
>>> 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/thumbyGrayscale.py", line 13, in <module>
KeyboardInterrupt: 
>
------------------------------------------------------
```
This was due to the IDE not recognising the OK response
when it was interleaved with the prompt message, e.g:
```
raw REPL; CTRL-B to exit
>OK
```