### PR TITLE
Keyboard interrupt in Fast Execute fix

### DIFF
--- a/js/repl.js
+++ b/js/repl.js
@@ -126,10 +126,7 @@ class ReplJS{
             var tempLines = this.COLLECTED_DATA.split('\r\n');
 
             for(var i=0; i<tempLines.length; i++){
-                // Sometimes the OK response gets mixed with the prompt, e.g:
-                //    0: "raw REPL; CTRL-B to exit"
-                //    1: ">OK"
-                if(tempLines[i] == "OK" || tempLines[i] == ">OK" || tempLines[i] == ">"){
+                if(tempLines[i] == "OK" || tempLines[i] == ">"){
                     return;
                 }
             }
@@ -150,6 +147,7 @@ class ReplJS{
     // found line set by startReaduntil.
     // Loops forever if never finds line set by startReaduntil()
     async haltUntilRead(omitOffset = 0){
+        var waitOmitOffset = 0;
 
         // Re-evaluate collected data for readUntil line every 85ms
         while (this.DISCONNECT == false) {
@@ -158,6 +156,11 @@ class ReplJS{
             for(var i=0; i<tempLines.length; i++){
                 if(tempLines[i] == this.READ_UNTIL_STRING || this.READ_UNTIL_STRING == "" || tempLines[i].indexOf(this.READ_UNTIL_STRING) != -1
                   || tempLines[i] == ">"){ // Keyboard interrupt
+                    // Wait for omitOffset lines
+                    if (i > tempLines.length-omitOffset && waitOmitOffset < 5) {
+                        waitOmitOffset++;
+                        break;
+                    }
                     this.READ_UNTIL_STRING = "";
 
                     // Output the rest of the lines that should not be hidden
@@ -242,7 +245,7 @@ class ReplJS{
     async softReset(){
         this.startReaduntil("MPY: soft reboot");
         await this.writeToDevice(this.CTRL_CMD_SOFTRESET);
-        await this.haltUntilRead(4);
+        await this.haltUntilRead(3);
     }
 
     // https://github.com/micropython/micropython/blob/master/tools/pyboard.py#L325
@@ -358,6 +361,7 @@ class ReplJS{
             return;
         }
         this.BUSY = true;
+        this.forceTermNewline();
 
         // Get into raw mode
         await this.getToRaw();
@@ -365,7 +369,6 @@ class ReplJS{
         // Not really needed for hiding output to terminal since raw does not echo
         // but is needed to only grab the FS lines/data
         this.startReaduntil(">");
-        this.forceTermNewline();
         await this.writeToDevice(lines + "\x04");
         await this.waitUntilOK();
         this.SPECIAL_FORCE_OUTPUT_FLAG = true;

--- a/js/repl.js
+++ b/js/repl.js
@@ -132,7 +132,7 @@ class ReplJS{
             }
 
             times = times + 1;
-            if(times >= 15){
+            if(times >= 30){
                 this.writeToDevice('');
                 console.error("Had to use ugly hack for hanging raw prompt...");
                 return;

--- a/js/repl.js
+++ b/js/repl.js
@@ -126,7 +126,10 @@ class ReplJS{
             var tempLines = this.COLLECTED_DATA.split('\r\n');
 
             for(var i=0; i<tempLines.length; i++){
-                if(tempLines[i] == "OK" || tempLines[i] == ">"){
+                // Sometimes the OK response gets mixed with the prompt, e.g:
+                //    0: "raw REPL; CTRL-B to exit"
+                //    1: ">OK"
+                if(tempLines[i] == "OK" || tempLines[i] == ">OK" || tempLines[i] == ">"){
                     return;
                 }
             }


### PR DESCRIPTION
This would show in the IDE Console like this:

MicroPython v1.19.1 on 2022-06-18; Raspberry Pi Pico with RP2040
Type "help()" for more information.
>>> 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/thumbyGrayscale.py", line 13, in <module>
KeyboardInterrupt: 
>
------------------------------------------------------
This was due to the IDE not recognising the OK response
when it was interleaved with previous message that were never captured, e.g:

raw REPL; CTRL-B to exit
>OK

This change handles response messages more predictably, avoiding
messages mixing together, and also gives Fast Execute a little bit longer
before bailing.

This approach also solves the rarer issue where the Filesystem panel
never fills after the Thumby is connected.
The underlying issue was how haltUntilRead would accept an omitOffset
argument that would consume additional lines after the expected line,
and that calling functions, like softReset, would expect haltUntilRead
to consume those lines. Unfortunately, haltUntilRead would only
consume additional lines that had already been received by the
time the expected line was encountered. If there was a delay with
the additional lines, they would not be consumed. This was a problem
for softReset, which would not always consume the raw mode prompt:
  raw REPL; CTRL-B to exit
  >
which would end up arriving while waitUntilOK was waiting for the
OK message, often messing up the detection.
This solution makes haltUntilRead wait until the additional offset
lines arrive, and time out if they don't arrive soon after.
This would of caused the softReset function to always pause, because
it was waiting on an additional line that would never arrive. Since
softReset is only used in raw mode, this has also been tuned to
the correct number of expected lines. In practice, even with this
reduction of the number of omit offset lines, it most likely
consumes more lines than it used to, because the additional
lines were subject to a delay that will only now be waited on.