### PR TITLE
Automatically call machine.reset after games execute

### DIFF
--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,6 +1,6 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
 
-from machine import mem32, freq
+from machine import mem32, freq, reset
 #Address of watchdog timer scratch register
 WATCHDOG_BASE=0x40058000
 SCRATCH0_ADDR=WATCHDOG_BASE+0x0C
@@ -17,6 +17,8 @@ if(mem32[SCRATCH0_ADDR]==1):
         __import__(gamePath)
     except ImportError:
         print("Thumby error: Couldn't load "+gamePath)
+    finally:
+        reset()
 
 
 


### PR DESCRIPTION
Previously it was encouraged that all games call thumby.reset,
(which just calls machine.reset).
This change eliminates that requirement and makes the menu system
not vulnerable to subsequent corruption of state.
Particularly noticable glitches can happen to the menu if games do not call
machine.reset cleanly, and where the state is corrupted.
This includes when a game calls thumbyGraphics.display.display.invert
and then crashes, thus leaving the menu with inverted colors,
or if a game uses _thread and then crashes, which would leave
the second core running code. This could include calls to the
display device and cause an interleaving of sending commands and data,
leading to undefined commands being sent to the display, potentially
outside the spefications of the display controller. Wierd effects
have been seen in practise such as a flipped image or bright
scrolling flashes.
This protects from all the above scenarios.