### PR TITLE
Tweaking main scripts and lib

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ Thumby Code Editor changelog!
 
 ####################
 
-December 20th, 2022
+December 22nd, 2022
 
 * Tweak core files; faster startup and reduced code imports (by community members acedent, hemlockmay).
 * Adjust contrast settings to support all OLED models (by community members agovtman, acedent).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ Thumby Code Editor changelog!
 
 ####################
 
-December 23rd, 2022
+December 27th, 2022
 
 * Tweak core files; faster startup and reduced code imports (by community members acedent, hemlockmay).
 * Adjust contrast settings to support all OLED models (by community members agovtman, acedent).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ Thumby Code Editor changelog!
 
 ####################
 
-December 29th, 2022
+January 8th, 2023
 
 * Tweak core files; faster startup and reduced code imports (by community members acedent, hemlockmay).
 * Adjust contrast settings to support all OLED models (by community members agovtman, acedent).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ Thumby Code Editor changelog!
 
 ####################
 
-December 27th, 2022
+December 29th, 2022
 
 * Tweak core files; faster startup and reduced code imports (by community members acedent, hemlockmay).
 * Adjust contrast settings to support all OLED models (by community members agovtman, acedent).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,13 @@ Thumby Code Editor changelog!
 
 ####################
 
+December 14th, 2022
+
+* Small cleanup of core files, including reduced code import (by community members acedent, hemlockmay).
+
+
+####################
+
 December 12th, 2022
 
 * Add support for grayscale bitmap builder when an editor with path "/thumbyGrayscale.py" is open (by community member hemlockmay)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ Thumby Code Editor changelog!
 
 ####################
 
-December 22nd, 2022
+December 23rd, 2022
 
 * Tweak core files; faster startup and reduced code imports (by community members acedent, hemlockmay).
 * Adjust contrast settings to support all OLED models (by community members agovtman, acedent).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ Thumby Code Editor changelog!
 
 ####################
 
-December 14th, 2022
+December 15th, 2022
 
 * Small cleanup of core files, including reduced code import (by community members acedent, hemlockmay).
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ Thumby Code Editor changelog!
 
 December 15th, 2022
 
-* Small cleanup of core files, including reduced code import (by community members acedent, hemlockmay).
+* Small cleanup of core files, including reduced code imports (by community members acedent, hemlockmay).
 
 
 ####################

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,9 +2,10 @@ Thumby Code Editor changelog!
 
 ####################
 
-December 15th, 2022
+December 17th, 2022
 
-* Small cleanup of core files, including reduced code imports (by community members acedent, hemlockmay).
+* Cleanup of core files; faster startup and reduced code imports (by community members acedent, hemlockmay).
+* Adjusted contrast settings to support all OLED models (by community members acedent, agovtman).
 
 
 ####################
@@ -13,13 +14,6 @@ December 12th, 2022
 
 * Add support for grayscale bitmap builder when an editor with path "/thumbyGrayscale.py" is open (by community member hemlockmay)
 * Add new https://code.thumby.us/play.html page for easily playing games through the emulator (by community member hemlockmay)
-
-
-####################
-
-November 11th, 2022
-
-* Fix Thumby main.py not printing exceptions
 
 
 ####################

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,10 +2,10 @@ Thumby Code Editor changelog!
 
 ####################
 
-December 17th, 2022
+December 20th, 2022
 
-* Cleanup of core files; faster startup and reduced code imports (by community members acedent, hemlockmay).
-* Adjusted contrast settings to support all OLED models (by community members acedent, agovtman).
+* Tweak core files; faster startup and reduced code imports (by community members acedent, hemlockmay).
+* Adjust contrast settings to support all OLED models (by community members agovtman, acedent).
 
 
 ####################

--- a/ThumbyGames/lib-emulator/ssd1306.py
+++ b/ThumbyGames/lib-emulator/ssd1306.py
@@ -1,9 +1,8 @@
 # MicroPython SSD1306 OLED driver, I2C and SPI interfaces- modified for Thumby
 # - Emulator edition
 
-# Last updated 14-Dec-2022
+# Last updated 20-Dec-2022
 
-from micropython import const
 import machine
 
 # Needed by emulator to quickly set pin state

--- a/ThumbyGames/lib-emulator/ssd1306.py
+++ b/ThumbyGames/lib-emulator/ssd1306.py
@@ -1,6 +1,8 @@
 # MicroPython SSD1306 OLED driver, I2C and SPI interfaces- modified for Thumby
+# - Emulator edition
 
-from time import ticks_ms, ticks_us
+# Last updated 14-Dec-2022
+
 from micropython import const
 import machine
 
@@ -90,5 +92,3 @@ class SSD1306_SPI(SSD1306):
     @micropython.native
     def write_data(self, buf):
         pass
-
-

--- a/ThumbyGames/lib-emulator/thumby.py
+++ b/ThumbyGames/lib-emulator/thumby.py
@@ -1,9 +1,10 @@
 # Thumby module.
+# - Emulator edition
 
 # Contains helpful abstractions between hardware features of Thumby and the uPython REPL.
 
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -21,20 +22,16 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-# Necessary things.
-#from machine import Pin, Timer, I2C, PWM, SPI, UART
-from machine import reset as machineReset
+from machine import reset as machineReset #, freq
 import emulator
-#import ssd1306
-#import os
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Grab initial frequency
 # __f0 = freq()
 # Speed us up so imports take less time
-# freq(250000000)
+# freq(250_000_000)
 
 from thumbyHardware import swL, swR, swU, swD, swA, swB, swBuzzer, IDPin, i2c, spi
 

--- a/ThumbyGames/lib-emulator/thumbyAudio.py
+++ b/ThumbyGames/lib-emulator/thumbyAudio.py
@@ -1,6 +1,8 @@
 # Thumby audio base
+# - Emulator edition
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -23,7 +25,7 @@ from machine import Timer
 from time import ticks_ms, ticks_diff
 import emulator
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Audio class, from which the audio namespace is defined.

--- a/ThumbyGames/lib-emulator/thumbyButton.py
+++ b/ThumbyGames/lib-emulator/thumbyButton.py
@@ -1,6 +1,8 @@
 # Thumby button base
+# - Emulator edition
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -21,7 +23,7 @@
 from thumbyHardware import swL, swR, swU, swD, swA, swB
 import emulator
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 class ButtonClass:
@@ -29,12 +31,12 @@ class ButtonClass:
         self.pin = pin
         self.lastState = False
         self.latchedPress = False
-    
+
     # Returns True if the button is currently pressed, False if not.
     @micropython.native
     def pressed(self):
         return False if self.pin.value() == 1 else True
-    
+
     # Returns True if the button was just pressed, False if not.
     @micropython.native
     def justPressed(self):
@@ -47,7 +49,7 @@ class ButtonClass:
             self.latchedPress = False
         self.lastState = currentState
         return returnVal
-    
+
     # Latches a button press state to be returned later through justPressed
     @micropython.native
     def update(self):
@@ -55,7 +57,7 @@ class ButtonClass:
         if(self.lastState == False and currentState==True):
             self.latchedPress = True
         self.lastState = currentState
-        
+
 # Button instantiation
 buttonA = ButtonClass(swA) # Left (A) button
 buttonB = ButtonClass(swB) # Right (B) button

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -28,7 +28,7 @@ from thumbyHardware import i2c, spi
 from thumbyButton import buttonA, buttonB, buttonU, buttonD, buttonL, buttonR
 import emulator
 
-# Last updated 14-Dec-2022
+# Last updated 15-Dec-2022
 __version__ = '1.9'
 
 # Graphics class, from which the gfx namespace is defined.
@@ -43,7 +43,6 @@ class GraphicsClass:
         self.frameRate = 0
         self.lastUpdateEnd = 0
         self.setFont('lib/font5x7.bin', 5, 7, 1)
-        #self.setFont('lib/font8x8.bin', 8, 8, 0)
         self.fill(0)
         
     @micropython.viper
@@ -370,7 +369,6 @@ class GraphicsClass:
             xFirst=0
         if xStart+width>72:
             blitWidth = 72-xStart
-        #print(y, yFirst, blitHeight, height)
         y=yFirst
         if(key==key):#ignore key value?
             while y < blitHeight:

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -20,7 +20,7 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-import ssd1306
+from ssd1306 import SSD1306_SPI
 from machine import Pin
 from os import stat
 from time import ticks_ms, ticks_diff, sleep_ms
@@ -387,4 +387,4 @@ class GraphicsClass:
         self.blitWithMask(s.bitmap, int(s.x), int(s.y), s.width, s.height, s.key, s.mirrorX, s.mirrorY, m.bitmap)
         
 # Graphics instantiation
-display = GraphicsClass(ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
+display = GraphicsClass(SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -1,6 +1,8 @@
 # Thumby graphics base
+# - Emulator edition
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -26,7 +28,7 @@ from thumbyHardware import i2c, spi
 from thumbyButton import buttonA, buttonB, buttonU, buttonD, buttonL, buttonR
 import emulator
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Graphics class, from which the gfx namespace is defined.

--- a/ThumbyGames/lib-emulator/thumbyHardware.py
+++ b/ThumbyGames/lib-emulator/thumbyHardware.py
@@ -1,6 +1,8 @@
 # Thumby hardware base
+# - Emulator edition
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -18,11 +20,11 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-from machine import Pin, Timer, I2C, PWM, SPI, UART
+from machine import Pin, Timer, I2C, PWM, SPI
 from machine import reset as machineReset
 import emulator
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Pin definitions for button inputs & buzzer.

--- a/ThumbyGames/lib-emulator/thumbyHardware.py
+++ b/ThumbyGames/lib-emulator/thumbyHardware.py
@@ -20,11 +20,10 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-from machine import Pin, PWM, SPI
-from machine import reset as machineReset
+from machine import Pin, PWM, SPI, reset as machineReset
 import emulator
 
-# Last updated 22-Dec-2022
+# Last updated 27-Dec-2022
 __version__ = '1.9'
 
 # Pin definitions for button inputs & buzzer.
@@ -67,4 +66,3 @@ else:
 # Wrap machine.reset() to be accessible as thumby.reset()
 def reset():
     machineReset()
-    

--- a/ThumbyGames/lib-emulator/thumbyHardware.py
+++ b/ThumbyGames/lib-emulator/thumbyHardware.py
@@ -20,11 +20,11 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-from machine import Pin, Timer, I2C, PWM, SPI
+from machine import Pin, PWM, SPI
 from machine import reset as machineReset
 import emulator
 
-# Last updated 14-Dec-2022
+# Last updated 15-Dec-2022
 __version__ = '1.9'
 
 # Pin definitions for button inputs & buzzer.
@@ -54,12 +54,15 @@ IDPin = Pin(14, Pin.IN, Pin.PULL_DOWN)
 IDPin = Pin(13, Pin.IN, Pin.PULL_DOWN)
 IDPin = Pin(12, Pin.IN, Pin.PULL_DOWN)
 
-i2c = None
-spi = None
-if(HWID==0):
-    i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1000000)
+
 if(HWID>=1):
-    spi = SPI(0, sck=Pin(18), mosi=Pin(19))#possible assignment of miso to 4 or 16?
+    spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
+    i2c = None
+else:
+    from machine import I2C
+    i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1_000_000)
+    spi = None
+
 
 # Wrap machine.reset() to be accessible as thumby.reset()
 def reset():

--- a/ThumbyGames/lib-emulator/thumbyHardware.py
+++ b/ThumbyGames/lib-emulator/thumbyHardware.py
@@ -24,7 +24,7 @@ from machine import Pin, PWM, SPI
 from machine import reset as machineReset
 import emulator
 
-# Last updated 15-Dec-2022
+# Last updated 22-Dec-2022
 __version__ = '1.9'
 
 # Pin definitions for button inputs & buzzer.
@@ -40,19 +40,19 @@ HWID = 0
 IDPin = Pin(15, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
     HWID+=1
+IDPin.init(IDPin.PULL_DOWN)
 IDPin = Pin(14, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
     HWID+=2
+IDPin.init(IDPin.PULL_DOWN)
 IDPin = Pin(13, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
     HWID+=4
+IDPin.init(IDPin.PULL_DOWN)
 IDPin = Pin(12, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
-    HWID+=8
-IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(14, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(13, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(12, Pin.IN, Pin.PULL_DOWN)
+   HWID+=8
+IDPin.init(IDPin.PULL_DOWN)
 
 
 if(HWID>=1):
@@ -67,3 +67,4 @@ else:
 # Wrap machine.reset() to be accessible as thumby.reset()
 def reset():
     machineReset()
+    

--- a/ThumbyGames/lib-emulator/thumbyLink.py
+++ b/ThumbyGames/lib-emulator/thumbyLink.py
@@ -1,6 +1,8 @@
 # Thumby link base
+# - Emulator edition
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -22,7 +24,7 @@ from machine import Pin, UART
 from time import ticks_ms, ticks_diff
 import emulator
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 class LinkClass:

--- a/ThumbyGames/lib-emulator/thumbySaves.py
+++ b/ThumbyGames/lib-emulator/thumbySaves.py
@@ -1,6 +1,8 @@
 # Thumby saves base
+# - Emulator edition
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -23,7 +25,7 @@ from ubinascii import a2b_base64 as b64dec, b2a_base64 as b64enc
 import os
 import emulator
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 class SavesClass:

--- a/ThumbyGames/lib-emulator/thumbySaves.py
+++ b/ThumbyGames/lib-emulator/thumbySaves.py
@@ -22,46 +22,46 @@
 
 from json import load as JSONLoad, dump as JSONDump
 from ubinascii import a2b_base64 as b64dec, b2a_base64 as b64enc
-import os
+from os import chdir, getcwd, mkdir, rename, remove, stat
 import emulator
 
-# Last updated 14-Dec-2022
+# Last updated 20-Dec-2022
 __version__ = '1.9'
 
 class SavesClass:
     def __init__(self):
         
-        oldDir = os.getcwd()
+        oldDir = getcwd()
         try:
-            os.stat("/Saves")
+            stat("/Saves")
         except OSError:
-            os.chdir("/")
-            os.mkdir("/Saves")
-            os.mkdir("/Saves/temp")
+            chdir("/")
+            mkdir("/Saves")
+            mkdir("/Saves/temp")
             
         self.savesPath = "/Saves"
         self.saveFile = None
         self.volatileDict = dict()
         
         try:
-            os.stat("/Saves/temp")
+            stat("/Saves/temp")
             self.setName("temp")
         except OSError:
             pass
         
-        os.chdir(oldDir)
+        chdir(oldDir)
     
     # Set a game save's working subdirectory in "/Saves/"
     # @micropython.viper
     def setName(self, subdir):
         
-        oldDir = os.getcwd()
+        oldDir = getcwd()
         self.savesPath = "/Saves/" + subdir
         
         try:
-            os.stat(self.savesPath)
+            stat(self.savesPath)
         except OSError:
-            os.mkdir(self.savesPath)
+            mkdir(self.savesPath)
         
         if type(self.saveFile) != type(None):
             self.saveFile.close()
@@ -79,7 +79,7 @@ class SavesClass:
                 self.saveFile.write("{}")
                 self.saveFile.seek(0, 0)
                 self.volatileDict = JSONLoad(self.saveFile)
-        os.chdir(oldDir)
+        chdir(oldDir)
     
     # Set entry in volatile dictionary
     @micropython.native
@@ -127,7 +127,7 @@ class SavesClass:
     # @micropython.native
     def save(self, backup = False):
         
-        oldDir = os.getcwd()
+        oldDir = getcwd()
         
         if(self.savesPath == "/Saves"): # If a directory hasn't been set, use a temporary one
             self.savesPath = "/Saves/temp"
@@ -137,16 +137,16 @@ class SavesClass:
         
         try:
             if(backup == True):
-                os.rename(self.savesPath+"/persistent.json", self.savesPath+"/backup.json")
+                rename(self.savesPath+"/persistent.json", self.savesPath+"/backup.json")
             else:
-                os.remove(self.savesPath+"/persistent.json")
+                remove(self.savesPath+"/persistent.json")
         except OSError:
             pass
         
         self.saveFile = open(self.savesPath+"/persistent.json", "w+")
         JSONDump(self.volatileDict, self.saveFile)
         self.saveFile.flush()
-        os.chdir(oldDir)
+        chdir(oldDir)
     
     # Return the current save path
     @micropython.viper

--- a/ThumbyGames/lib-emulator/thumbySprite.py
+++ b/ThumbyGames/lib-emulator/thumbySprite.py
@@ -1,6 +1,8 @@
 # Thumby sprite base
+# - Emulator edition
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -18,10 +20,10 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-import os
+from os import stat
 import emulator
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Sprite class for holding pixel data 
@@ -40,7 +42,7 @@ class Sprite:
             self.bitmap = bytearray(self.bitmapByteCount)
             self.file = open(self.bitmapSource,'rb')
             self.file.readinto(self.bitmap)
-            self.frameCount = os.stat(self.bitmapSource)[6] // self.bitmapByteCount
+            self.frameCount = stat(self.bitmapSource)[6] // self.bitmapByteCount
         elif type(self.bitmapSource)==bytearray:
             self.bitmap = memoryview(self.bitmapSource)[0:self.bitmapByteCount]
             self.frameCount = len(self.bitmapSource) // self.bitmapByteCount
@@ -62,6 +64,5 @@ class Sprite:
             if type(self.bitmapSource)==str:
                 self.file.seek(offset)
                 self.file.readinto(self.bitmap)
-                #f.close()
             elif type(self.bitmapSource)==bytearray:
                 self.bitmap = memoryview(self.bitmapSource)[offset:offset+self.bitmapByteCount]

--- a/ThumbyGames/lib/ssd1306.py
+++ b/ThumbyGames/lib/ssd1306.py
@@ -1,8 +1,7 @@
 # MicroPython SSD1306 OLED driver, I2C and SPI interfaces- modified for Thumby
 
-# Last updated 14-Dec-2022
+# Last updated 20-Dec-2022
 
-from micropython import const
 
 class SSD1306():
     def __init__(self, width, height, external_vcc):

--- a/ThumbyGames/lib/ssd1306.py
+++ b/ThumbyGames/lib/ssd1306.py
@@ -1,5 +1,7 @@
 # MicroPython SSD1306 OLED driver, I2C and SPI interfaces- modified for Thumby
 
+# Last updated 14-Dec-2022
+
 from micropython import const
 
 class SSD1306():

--- a/ThumbyGames/lib/ssd1306.py
+++ b/ThumbyGames/lib/ssd1306.py
@@ -10,7 +10,6 @@ class SSD1306():
         self.external_vcc = external_vcc
         self.pages = self.height // 8
         self.buffer = bytearray(self.pages * self.width)
-        #self.init_display()
 
     def init_display(self):
         self.reset()
@@ -19,8 +18,6 @@ class SSD1306():
             0x10 if self.external_vcc else 0x14,0xAD,0x30,0xAE | 0x01
         ):
             self.write_cmd(cmd)
-        #self.fill(0)
-        #self.show()
 
     def poweroff(self):
         self.write_cmd(0xAE | 0x00)
@@ -79,7 +76,6 @@ class SSD1306_I2C(SSD1306):
 
     @micropython.native
     def write_data(self, buf):
-        #self.write_list[1] = buf
         self.i2c.writeto_mem(self.addr, 0x40, buf)
 
 
@@ -124,7 +120,6 @@ class SSD1306_SPI(SSD1306):
         self.spi.write(self.cmdWindow)
         self.cs(1)
 
-
     @micropython.native
     def write_data(self, buf):
         self.spi.init(baudrate=self.rate, polarity=0, phase=0)
@@ -133,5 +128,3 @@ class SSD1306_SPI(SSD1306):
         self.cs(0)
         self.spi.write(buf)
         self.cs(1)
-
-

--- a/ThumbyGames/lib/ssd1306.py
+++ b/ThumbyGames/lib/ssd1306.py
@@ -1,6 +1,5 @@
 # MicroPython SSD1306 OLED driver, I2C and SPI interfaces- modified for Thumby
 
-from time import ticks_ms, ticks_us
 from micropython import const
 
 class SSD1306():
@@ -99,7 +98,7 @@ class SSD1306_SPI(SSD1306):
         sleep_ms(1)
         self.res(0)
         sleep_ms(10)
-        self.res(1)        
+        self.res(1)
         sleep_ms(10)
 
     @micropython.native

--- a/ThumbyGames/lib/thumby.py
+++ b/ThumbyGames/lib/thumby.py
@@ -21,19 +21,15 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-# Necessary things.
-#from machine import Pin, Timer, I2C, PWM, SPI, UART
-from machine import reset as machineReset, freq
-#import ssd1306
-#import os
 
 # Last updated 11/11/2022 for menu reset change
 __version__ = '1.9'
 
+from machine import reset as machineReset, freq
 # Grab initial frequency
 __f0 = freq()
 # Speed us up so imports take less time
-freq(250000000)
+freq(250_000_000)
 
 from thumbyHardware import swL, swR, swU, swD, swA, swB, swBuzzer, IDPin, i2c, spi, reset
 

--- a/ThumbyGames/lib/thumby.py
+++ b/ThumbyGames/lib/thumby.py
@@ -3,7 +3,7 @@
 # Contains helpful abstractions between hardware features of Thumby and the uPython REPL.
 
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -21,11 +21,11 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
+from machine import reset as machineReset, freq
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
-from machine import reset as machineReset, freq
 # Grab initial frequency
 __f0 = freq()
 # Speed us up so imports take less time

--- a/ThumbyGames/lib/thumbyAudio.py
+++ b/ThumbyGames/lib/thumbyAudio.py
@@ -1,6 +1,7 @@
 # Thumby audio base
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -22,7 +23,7 @@ from thumbyHardware import swBuzzer
 from machine import Timer
 from time import ticks_ms, ticks_diff
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Audio class, from which the audio namespace is defined.

--- a/ThumbyGames/lib/thumbyButton.py
+++ b/ThumbyGames/lib/thumbyButton.py
@@ -1,6 +1,7 @@
 # Thumby button base
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -20,7 +21,7 @@
 
 from thumbyHardware import swL, swR, swU, swD, swA, swB
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 class ButtonClass:
@@ -28,12 +29,12 @@ class ButtonClass:
         self.pin = pin
         self.lastState = False
         self.latchedPress = False
-    
+
     # Returns True if the button is currently pressed, False if not.
     @micropython.native
     def pressed(self):
         return False if self.pin.value() == 1 else True
-    
+
     # Returns True if the button was just pressed, False if not.
     @micropython.native
     def justPressed(self):
@@ -46,7 +47,7 @@ class ButtonClass:
             self.latchedPress = False
         self.lastState = currentState
         return returnVal
-    
+
     # Latches a button press state to be returned later through justPressed
     @micropython.native
     def update(self):
@@ -54,7 +55,7 @@ class ButtonClass:
         if(self.lastState == False and currentState==True):
             self.latchedPress = True
         self.lastState = currentState
-        
+
 # Button instantiation
 buttonA = ButtonClass(swA) # Left (A) button
 buttonB = ButtonClass(swB) # Right (B) button

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -19,14 +19,14 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-import ssd1306
+from ssd1306 import SSD1306_SPI
 from machine import Pin
 from os import stat
 from time import ticks_ms, ticks_diff, sleep_ms
 from thumbyHardware import i2c, spi
 from thumbyButton import buttonA, buttonB, buttonU, buttonD, buttonL, buttonR
 
-# Last updated 14-Dec-2022
+# Last updated 15-Dec-2022
 __version__ = '1.9'
 
 # Graphics class, from which the gfx namespace is defined.
@@ -377,10 +377,10 @@ class GraphicsClass:
     @micropython.native
     def drawSpriteWithMask(self, s, m):
         self.blitWithMask(s.bitmap, int(s.x), int(s.y), s.width, s.height, s.key, s.mirrorX, s.mirrorY, m.bitmap)
-        
+
 # Graphics instantiation
-display=None
-if(i2c):
-    display = GraphicsClass(ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18)), 72, 40)
 if(spi):
-    display = GraphicsClass(ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
+    display = GraphicsClass(SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
+else:
+    from ssd1306 import SSD1306_I2C
+    display = GraphicsClass(SSD1306_I2C(72, 40, i2c, res=Pin(18)), 72, 40)

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -40,7 +40,6 @@ class GraphicsClass:
         self.frameRate = 0
         self.lastUpdateEnd = 0
         self.setFont('lib/font5x7.bin', 5, 7, 1)
-        #self.setFont('lib/font8x8.bin', 8, 8, 0)
         self.fill(0)
 
     @micropython.native
@@ -363,7 +362,7 @@ class GraphicsClass:
         if xStart+width>72:
             blitWidth = 72-xStart
         y=yFirst
-        if(key==key):#ignore key value?
+        if(key==key): # ignore key value?
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -1,6 +1,7 @@
 # Thumby graphics base
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -25,7 +26,7 @@ from time import ticks_ms, ticks_diff, sleep_ms
 from thumbyHardware import i2c, spi
 from thumbyButton import buttonA, buttonB, buttonU, buttonD, buttonL, buttonR
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Graphics class, from which the gfx namespace is defined.

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -362,7 +362,6 @@ class GraphicsClass:
             xFirst=0
         if xStart+width>72:
             blitWidth = 72-xStart
-        #print(y, yFirst, blitHeight, height)
         y=yFirst
         if(key==key):#ignore key value?
             while y < blitHeight:

--- a/ThumbyGames/lib/thumbyHardware.py
+++ b/ThumbyGames/lib/thumbyHardware.py
@@ -18,7 +18,7 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-from machine import Pin, Timer, I2C, PWM, SPI, UART
+from machine import Pin, Timer, I2C, PWM, SPI
 from machine import reset as machineReset
 
 # Last updated 11/11/2022 for menu reset change

--- a/ThumbyGames/lib/thumbyHardware.py
+++ b/ThumbyGames/lib/thumbyHardware.py
@@ -1,6 +1,7 @@
 # Thumby hardware base
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -21,7 +22,7 @@
 from machine import Pin, Timer, I2C, PWM, SPI
 from machine import reset as machineReset
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Pin definitions for button inputs & buzzer.

--- a/ThumbyGames/lib/thumbyHardware.py
+++ b/ThumbyGames/lib/thumbyHardware.py
@@ -19,7 +19,7 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-from machine import Pin, Timer, I2C, PWM, SPI
+from machine import Pin, PWM, SPI
 from machine import reset as machineReset
 
 # Last updated 15-Dec-2022
@@ -52,12 +52,14 @@ IDPin = Pin(14, Pin.IN, Pin.PULL_DOWN)
 IDPin = Pin(13, Pin.IN, Pin.PULL_DOWN)
 IDPin = Pin(12, Pin.IN, Pin.PULL_DOWN)
 
-i2c = None
-spi = None
+
 if(HWID>=1):
     spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
+    i2c = None
 else:
+    from machine import I2C
     i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1_000_000)
+    spi = None
 
 
 # Wrap machine.reset() to be accessible as thumby.reset()

--- a/ThumbyGames/lib/thumbyHardware.py
+++ b/ThumbyGames/lib/thumbyHardware.py
@@ -22,7 +22,7 @@
 from machine import Pin, PWM, SPI
 from machine import reset as machineReset
 
-# Last updated 15-Dec-2022
+# Last updated 22-Dec-2022
 __version__ = '1.9'
 
 # Pin definitions for button inputs & buzzer.
@@ -38,19 +38,19 @@ HWID = 0
 IDPin = Pin(15, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
     HWID+=1
+IDPin.init(IDPin.PULL_DOWN)
 IDPin = Pin(14, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
     HWID+=2
+IDPin.init(IDPin.PULL_DOWN)
 IDPin = Pin(13, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
     HWID+=4
+IDPin.init(IDPin.PULL_DOWN)
 IDPin = Pin(12, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
-    HWID+=8
-IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(14, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(13, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(12, Pin.IN, Pin.PULL_DOWN)
+   HWID+=8
+IDPin.init(IDPin.PULL_DOWN)
 
 
 if(HWID>=1):
@@ -65,3 +65,4 @@ else:
 # Wrap machine.reset() to be accessible as thumby.reset()
 def reset():
     machineReset()
+    

--- a/ThumbyGames/lib/thumbyHardware.py
+++ b/ThumbyGames/lib/thumbyHardware.py
@@ -22,7 +22,7 @@
 from machine import Pin, Timer, I2C, PWM, SPI
 from machine import reset as machineReset
 
-# Last updated 14-Dec-2022
+# Last updated 15-Dec-2022
 __version__ = '1.9'
 
 # Pin definitions for button inputs & buzzer.
@@ -54,10 +54,11 @@ IDPin = Pin(12, Pin.IN, Pin.PULL_DOWN)
 
 i2c = None
 spi = None
-if(HWID==0):
-    i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1000000)
 if(HWID>=1):
-    spi = SPI(0, sck=Pin(18), mosi=Pin(19))#possible assignment of miso to 4 or 16?
+    spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
+else:
+    i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1_000_000)
+
 
 # Wrap machine.reset() to be accessible as thumby.reset()
 def reset():

--- a/ThumbyGames/lib/thumbyHardware.py
+++ b/ThumbyGames/lib/thumbyHardware.py
@@ -19,10 +19,9 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-from machine import Pin, PWM, SPI
-from machine import reset as machineReset
+from machine import Pin, PWM, SPI, reset as machineReset
 
-# Last updated 22-Dec-2022
+# Last updated 27-Dec-2022
 __version__ = '1.9'
 
 # Pin definitions for button inputs & buzzer.
@@ -65,4 +64,3 @@ else:
 # Wrap machine.reset() to be accessible as thumby.reset()
 def reset():
     machineReset()
-    

--- a/ThumbyGames/lib/thumbyLink.py
+++ b/ThumbyGames/lib/thumbyLink.py
@@ -1,6 +1,7 @@
 # Thumby link base
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -21,14 +22,14 @@
 from machine import Pin, UART
 from time import ticks_ms, ticks_diff
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 class LinkClass:
     def __init__(self):
         self.initialized = False
-    
-    
+
+
     @micropython.native
     def init(self):
         self.rxPin = Pin(1, Pin.IN)

--- a/ThumbyGames/lib/thumbySaves.py
+++ b/ThumbyGames/lib/thumbySaves.py
@@ -21,45 +21,45 @@
 
 from json import load as JSONLoad, dump as JSONDump
 from ubinascii import a2b_base64 as b64dec, b2a_base64 as b64enc
-import os
+from os import chdir, getcwd, mkdir, rename, remove, stat
 
-# Last updated 14-Dec-2022
+# Last updated 20-Dec-2022
 __version__ = '1.9'
 
 class SavesClass:
     def __init__(self):
         
-        oldDir = os.getcwd()
+        oldDir = getcwd()
         try:
-            os.stat("/Saves")
+            stat("/Saves")
         except OSError:
-            os.chdir("/")
-            os.mkdir("/Saves")
-            os.mkdir("/Saves/temp")
+            chdir("/")
+            mkdir("/Saves")
+            mkdir("/Saves/temp")
             
         self.savesPath = "/Saves"
         self.saveFile = None
         self.volatileDict = dict()
         
         try:
-            os.stat("/Saves/temp")
+            stat("/Saves/temp")
             self.setName("temp")
         except OSError:
             pass
         
-        os.chdir(oldDir)
+        chdir(oldDir)
     
     # Set a game save's working subdirectory in "/Saves/"
     @micropython.viper
     def setName(self, subdir):
         
-        oldDir = os.getcwd()
+        oldDir = getcwd()
         self.savesPath = "/Saves/" + subdir
         
         try:
-            os.stat(self.savesPath)
+            stat(self.savesPath)
         except OSError:
-            os.mkdir(self.savesPath)
+            mkdir(self.savesPath)
         
         if type(self.saveFile) != type(None):
             self.saveFile.close()
@@ -77,7 +77,7 @@ class SavesClass:
                 self.saveFile.write("{}")
                 self.saveFile.seek(0, 0)
                 self.volatileDict = JSONLoad(self.saveFile)
-        os.chdir(oldDir)
+        chdir(oldDir)
     
     # Set entry in volatile dictionary
     @micropython.native
@@ -125,7 +125,7 @@ class SavesClass:
     @micropython.native
     def save(self, backup = False):
         
-        oldDir = os.getcwd()
+        oldDir = getcwd()
         
         if(self.savesPath == "/Saves"): # If a directory hasn't been set, use a temporary one
             self.savesPath = "/Saves/temp"
@@ -135,16 +135,16 @@ class SavesClass:
         
         try:
             if(backup == True):
-                os.rename(self.savesPath+"/persistent.json", self.savesPath+"/backup.json")
+                rename(self.savesPath+"/persistent.json", self.savesPath+"/backup.json")
             else:
-                os.remove(self.savesPath+"/persistent.json")
+                remove(self.savesPath+"/persistent.json")
         except OSError:
             pass
         
         self.saveFile = open(self.savesPath+"/persistent.json", "w+")
         JSONDump(self.volatileDict, self.saveFile)
         self.saveFile.flush()
-        os.chdir(oldDir)
+        chdir(oldDir)
     
     # Return the current save path
     @micropython.viper

--- a/ThumbyGames/lib/thumbySaves.py
+++ b/ThumbyGames/lib/thumbySaves.py
@@ -1,6 +1,7 @@
 # Thumby saves base
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -22,7 +23,7 @@ from json import load as JSONLoad, dump as JSONDump
 from ubinascii import a2b_base64 as b64dec, b2a_base64 as b64enc
 import os
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 class SavesClass:

--- a/ThumbyGames/lib/thumbySprite.py
+++ b/ThumbyGames/lib/thumbySprite.py
@@ -18,7 +18,7 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-import os
+from os import stat
 
 # Last updated 11/11/2022 for menu reset change
 __version__ = '1.9'
@@ -39,7 +39,7 @@ class Sprite:
             self.bitmap = bytearray(self.bitmapByteCount)
             self.file = open(self.bitmapSource,'rb')
             self.file.readinto(self.bitmap)
-            self.frameCount = os.stat(self.bitmapSource)[6] // self.bitmapByteCount
+            self.frameCount = stat(self.bitmapSource)[6] // self.bitmapByteCount
         elif type(self.bitmapSource)==bytearray:
             self.bitmap = memoryview(self.bitmapSource)[0:self.bitmapByteCount]
             self.frameCount = len(self.bitmapSource) // self.bitmapByteCount

--- a/ThumbyGames/lib/thumbySprite.py
+++ b/ThumbyGames/lib/thumbySprite.py
@@ -1,6 +1,7 @@
 # Thumby sprite base
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -20,7 +21,7 @@
 
 from os import stat
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 14-Dec-2022
 __version__ = '1.9'
 
 # Sprite class for holding pixel data 

--- a/ThumbyGames/lib/thumbySprite.py
+++ b/ThumbyGames/lib/thumbySprite.py
@@ -61,6 +61,5 @@ class Sprite:
             if type(self.bitmapSource)==str:
                 self.file.seek(offset)
                 self.file.readinto(self.bitmap)
-                #f.close()
             elif type(self.bitmapSource)==bytearray:
                 self.bitmap = memoryview(self.bitmapSource)[offset:offset+self.bitmapByteCount]

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,5 +1,5 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
-# Last updated 14-Dec-2022
+# Last updated 15-Dec-2022
 
 from machine import mem32, freq, reset
 freq(133_000_000)
@@ -23,15 +23,13 @@ if(mem32[SCRATCH0_ADDR]==1):
         from time import sleep_ms
         print("\nThis Thumby script crashed... :(")
         print_exception(e)
-        
-        # Let the exception print before resetting
         sleep_ms(1000)
         reset()
     else:
         reset()
 
 
-from machine import Pin, Timer, I2C, SPI
+from machine import Pin, I2C, SPI
 import ssd1306
 
 
@@ -46,34 +44,15 @@ except OSError:
 
 brightnessVals=[0,28,127]
 
-HWID = 0
+
 IDPin = Pin(15, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
-    HWID+=1
-IDPin = Pin(14, Pin.IN, Pin.PULL_UP)
-if(IDPin.value() == 0):
-    HWID+=2
-IDPin = Pin(13, Pin.IN, Pin.PULL_UP)
-if(IDPin.value() == 0):
-    HWID+=4
-IDPin = Pin(12, Pin.IN, Pin.PULL_UP)
-if(IDPin.value() == 0):
-    HWID+=8
-IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(14, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(13, Pin.IN, Pin.PULL_DOWN)
-IDPin = Pin(12, Pin.IN, Pin.PULL_DOWN)
-
-
-i2c = None
-spi = None
-display=None
-if(HWID==0):
-    i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1000000)
-    display = ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18))
-if(HWID>=1):
-    spi = SPI(0, sck=Pin(18), mosi=Pin(19)) #possible assignment of miso to 4 or 16?
+    spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
     display = ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16))
+else:
+    i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1_000_000)
+    display = ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18))
+IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)
 
 display.init_display()
 display.contrast(brightnessVals[brightnessSetting])
@@ -85,5 +64,6 @@ display.show()
 
 
 import menu
+
 
 reset()

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,5 +1,5 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
-# Last updated 17-Dec-2022
+# Last updated 22-Dec-2022
 
 from machine import freq, mem32, reset
 freq(133_000_000)
@@ -28,18 +28,27 @@ if(mem32[0x4005800C]==1): # Watchdog timer scratch register
 
 
 from machine import Pin, SPI
-import ssd1306
+from ssd1306 import SSD1306_SPI
 
+HWID = 0
 IDPin = Pin(15, Pin.IN, Pin.PULL_UP)
-# Future hardware revsions may need to check HWID with GPIO pins 14–12.
 if(IDPin.value() == 0):
+    HWID+=1
+IDPin.init(IDPin.PULL_DOWN)
+IDPin = Pin(14, Pin.IN, Pin.PULL_UP)
+if(IDPin.value() == 0):
+    HWID+=2
+IDPin.init(IDPin.PULL_DOWN)
+# Check HWID with GPIO pins 13–12 for future revisions
+
+if(HWID>=1):
     spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
-    display = ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16))
+    display = SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16))
 else:
     from machine import I2C
+    from ssd1306 import SSD1306_I2C
     i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1_000_000)
-    display = ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18))
-IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)
+    display = SSD1306_I2C(72, 40, i2c, res=Pin(18))
 display.init_display()
 
 brightnessSetting=1

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,6 +1,6 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
 
-from machine import mem32, freq, reset, lightsleep
+from machine import mem32, freq, reset
 #Address of watchdog timer scratch register
 WATCHDOG_BASE=0x40058000
 SCRATCH0_ADDR=WATCHDOG_BASE+0x0C
@@ -19,11 +19,12 @@ if(mem32[SCRATCH0_ADDR]==1):
         print("Thumby error: Couldn't load "+gamePath)
     except Exception as e:
         from sys import print_exception
+        from time import sleep_ms
         print("\nThis Thumby script crashed... :(")
         print_exception(e)
         
         # Let the exception print before resetting
-        lightsleep(1000)
+        sleep_ms(1000)
         reset()
     else:
         reset()

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,4 +1,5 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
+# Last updated 14-Dec-2022
 
 from machine import mem32, freq, reset
 freq(133_000_000)

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,6 +1,6 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
 
-from machine import mem32, freq, reset
+from machine import mem32, freq, reset, lightsleep
 #Address of watchdog timer scratch register
 WATCHDOG_BASE=0x40058000
 SCRATCH0_ADDR=WATCHDOG_BASE+0x0C
@@ -19,12 +19,11 @@ if(mem32[SCRATCH0_ADDR]==1):
         print("Thumby error: Couldn't load "+gamePath)
     except Exception as e:
         import sys
-        import time
         print("\nThis Thumby script crashed... :(")
         sys.print_exception(e)
         
         # Let the exception print before resetting
-        time.sleep(1)
+        lightsleep(1000)
         reset()
     else:
         reset()
@@ -73,7 +72,7 @@ if(HWID==0):
     i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1000000)
     display = ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18))
 if(HWID>=1):
-    spi = SPI(0, sck=Pin(18), mosi=Pin(19))#possible assignment of miso to 4 or 16?
+    spi = SPI(0, sck=Pin(18), mosi=Pin(19)) #possible assignment of miso to 4 or 16?
     display = ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16))
 
 display.init_display()
@@ -85,7 +84,6 @@ f.close()
 display.show()
 
 
-
 import menu
 
-machine.reset()
+reset()

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,10 +1,10 @@
-# Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
-# Last updated 22-Dec-2022
+# Thumby main.py- quick initialization and splashscreen before menu.py is called
+# Last updated 29-Dec-2022
 
 from machine import freq, mem32, reset
 freq(133_000_000)
 
-if(mem32[0x4005800C]==1): # Watchdog timer scratch register
+if(mem32[0x4005800C]==1): # WDT scratch register '0'
     mem32[0x4005800C]=0
     gamePath=''
     conf = open("thumby.cfg", "r").read().split(',')
@@ -39,7 +39,7 @@ IDPin = Pin(14, Pin.IN, Pin.PULL_UP)
 if(IDPin.value() == 0):
     HWID+=2
 IDPin.init(IDPin.PULL_DOWN)
-# Check HWID with GPIO pins 13–12 for future revisions
+# Check HWID with GPIO pins 13-12 for future revisions
 
 if(HWID>=1):
     spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -32,6 +32,15 @@ if(mem32[SCRATCH0_ADDR]==1):
 from machine import Pin, I2C, SPI
 import ssd1306
 
+IDPin = Pin(15, Pin.IN, Pin.PULL_UP)
+if(IDPin.value() == 0):
+    spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
+    display = ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16))
+else:
+    i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1_000_000)
+    display = ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18))
+IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)
+display.init_display()
 
 brightnessSetting=2
 try:
@@ -41,20 +50,7 @@ try:
             brightnessSetting = int(conf[k+1])
 except OSError:
     pass
-
 brightnessVals=[0,28,127]
-
-
-IDPin = Pin(15, Pin.IN, Pin.PULL_UP)
-if(IDPin.value() == 0):
-    spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
-    display = ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16))
-else:
-    i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1_000_000)
-    display = ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18))
-IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)
-
-display.init_display()
 display.contrast(brightnessVals[brightnessSetting])
 
 f=open('lib/TClogo.bin')

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -3,18 +3,16 @@
 
 from machine import freq, mem32, reset
 freq(133_000_000)
-#Address of watchdog timer scratch register
-WATCHDOG_BASE=0x40058000
-SCRATCH0_ADDR=WATCHDOG_BASE+0x0C
 
-if(mem32[SCRATCH0_ADDR]==1):
-    mem32[SCRATCH0_ADDR]=0
+if(mem32[0x4005800C]==1): # Watchdog timer scratch register
+    mem32[0x4005800C]=0
     gamePath=''
     conf = open("thumby.cfg", "r").read().split(',')
     for k in range(len(conf)):
         if(conf[k] == "lastgame"):
             gamePath = conf[k+1]
     try:
+        freq(125_000_000)
         __import__(gamePath)
     except ImportError:
         print("Thumby error: Couldn't load "+gamePath)

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -12,7 +12,7 @@ if(mem32[SCRATCH0_ADDR]==1):
     for k in range(len(conf)):
         if(conf[k] == "lastgame"):
             gamePath = conf[k+1]
-    freq(125000000)
+    freq(125_000_000)
     try:
         __import__(gamePath)
     except ImportError:
@@ -31,8 +31,7 @@ if(mem32[SCRATCH0_ADDR]==1):
 
 
 
-from machine import Pin, Timer, I2C, PWM, SPI, freq, WDT
-from time import sleep_ms, ticks_ms, sleep_us, ticks_us
+from machine import Pin, Timer, I2C, SPI
 import ssd1306
 
 

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,7 +1,7 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
 # Last updated 15-Dec-2022
 
-from machine import mem32, freq, reset
+from machine import freq, mem32, reset
 freq(133_000_000)
 #Address of watchdog timer scratch register
 WATCHDOG_BASE=0x40058000
@@ -29,7 +29,7 @@ if(mem32[SCRATCH0_ADDR]==1):
         reset()
 
 
-from machine import Pin, I2C, SPI
+from machine import Pin, SPI
 import ssd1306
 
 IDPin = Pin(15, Pin.IN, Pin.PULL_UP)
@@ -37,6 +37,7 @@ if(IDPin.value() == 0):
     spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
     display = ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16))
 else:
+    from machine import I2C
     i2c = I2C(0, sda=Pin(16), scl=Pin(17), freq=1_000_000)
     display = ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18))
 IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,5 +1,5 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
-# Last updated 15-Dec-2022
+# Last updated 17-Dec-2022
 
 from machine import freq, mem32, reset
 freq(133_000_000)
@@ -33,6 +33,7 @@ from machine import Pin, SPI
 import ssd1306
 
 IDPin = Pin(15, Pin.IN, Pin.PULL_UP)
+# Future hardware revsions may need to check HWID with GPIO pins 14–12.
 if(IDPin.value() == 0):
     spi = SPI(0, sck=Pin(18), mosi=Pin(19)) # Assign miso to 4 or 16?
     display = ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16))
@@ -43,7 +44,7 @@ else:
 IDPin = Pin(15, Pin.IN, Pin.PULL_DOWN)
 display.init_display()
 
-brightnessSetting=2
+brightnessSetting=1
 try:
     conf = open("thumby.cfg", "r").read().split(',')
     for k in range(len(conf)):
@@ -51,7 +52,7 @@ try:
             brightnessSetting = int(conf[k+1])
 except OSError:
     pass
-brightnessVals=[0,28,127]
+brightnessVals=[1,28,127]
 display.contrast(brightnessVals[brightnessSetting])
 
 f=open('lib/TClogo.bin')

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -18,9 +18,9 @@ if(mem32[SCRATCH0_ADDR]==1):
     except ImportError:
         print("Thumby error: Couldn't load "+gamePath)
     except Exception as e:
-        import sys
+        from sys import print_exception
         print("\nThis Thumby script crashed... :(")
-        sys.print_exception(e)
+        print_exception(e)
         
         # Let the exception print before resetting
         lightsleep(1000)

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -1,6 +1,7 @@
 # Thumby main.py- quick initialization to display the TinyCircuits logo before menu.py is called
 
 from machine import mem32, freq, reset
+freq(133_000_000)
 #Address of watchdog timer scratch register
 WATCHDOG_BASE=0x40058000
 SCRATCH0_ADDR=WATCHDOG_BASE+0x0C
@@ -12,7 +13,6 @@ if(mem32[SCRATCH0_ADDR]==1):
     for k in range(len(conf)):
         if(conf[k] == "lastgame"):
             gamePath = conf[k+1]
-    freq(125_000_000)
     try:
         __import__(gamePath)
     except ImportError:
@@ -28,7 +28,6 @@ if(mem32[SCRATCH0_ADDR]==1):
         reset()
     else:
         reset()
-
 
 
 from machine import Pin, Timer, I2C, SPI

--- a/ThumbyGames/main.py
+++ b/ThumbyGames/main.py
@@ -38,7 +38,6 @@ import ssd1306
 brightnessSetting=2
 try:
     conf = open("thumby.cfg", "r").read().split(',')
-    print(conf)
     for k in range(len(conf)):
         if(conf[k] == "brightness"):
             brightnessSetting = int(conf[k+1])

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -117,9 +117,9 @@ for k in range(len(shortFiles)):
 settingsSelpos = -1
 SettingsScroll = 0
 
-print(gc.mem_free())
-print(gc.collect())
-print(gc.mem_free())
+#print(gc.mem_free())
+#print(gc.collect())
+#print(gc.mem_free())
 
 
 def writeCenteredText(text, x, y ,color):
@@ -418,7 +418,6 @@ while True:
                     if(settingsSelpos==0):
                         audioSetting= (audioSetting+1) % 2
                         thumby.audio.setEnabled(audioSetting)
-                        print(audioSetting)
                         saveConfigSetting("audioenabled", str(audioSetting))
                         thumby.audio.play(500,20)
                     if(settingsSelpos==1):

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -2,9 +2,10 @@
 
 from machine import freq
 freq(250_000_000)
+from machine import mem32, soft_reset
 from time import ticks_ms, ticks_us, sleep_ms
 from os import listdir, stat
-from gc import collect
+from gc import collect as gc_collect
 import thumby
 freq(48_000_000)
 thumby.display.setFont('lib/font5x7.bin', 5, 7, 1)
@@ -118,8 +119,9 @@ for k in range(len(shortFiles)):
 settingsSelpos = -1
 SettingsScroll = 0
 
-# garbage collection
-collect()
+
+gc_collect() # Garbage collection
+
 
 def writeCenteredText(text, x, y ,color):
     textLen = min(len(text),10)
@@ -189,12 +191,8 @@ def launchGame():
     if(selpos>=0):
         gamePath="/Games/"+files[selpos]+"/"+files[selpos]+".py"
         saveConfigSetting("lastgame", gamePath)
-    import machine
-    #Address of watchdog timer scratch register
-    WATCHDOG_BASE=0x40058000
-    SCRATCH0_ADDR=WATCHDOG_BASE+0x0C
-    machine.mem32[SCRATCH0_ADDR]=1
-    machine.soft_reset()
+    mem32[0x4005800C]=1 # Watchdog timer scratch register
+    soft_reset()
 
 
 while True:

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,6 +1,6 @@
 
 from machine import freq
-freq(125_000_000)
+freq(250_000_000)
 from time import ticks_ms, ticks_us
 import os
 import gc

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,7 +1,7 @@
 
 from machine import freq
 freq(125_000_000)
-from time import sleep_ms, ticks_ms, ticks_us
+from time import ticks_ms, ticks_us
 import os
 import gc
 import thumby
@@ -328,7 +328,8 @@ while True:
             creditsScrollOffset = (creditsScrollPosition)%(width)
             xScrollTarget = -216
             noButtonPress = True
-            machine.lightsleep(100)
+            from machine import lightsleep
+            lightsleep(100)
                     
     if(xScrollPos<-144 or (xScrollTarget==-72 and xScrollPos<-72)):
         if(xScrollPos==-216):

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -54,7 +54,7 @@ creditsScrollPosition = -1
 width=(6*16 + 10)
 firstLine = 0
 creditsScrollOffset=-1
-    
+
 
 TCSplash=thumby.Sprite(72, 24, 'lib/TClogo.bin',0,0,-1)
 thumbySplash=thumby.Sprite(72, 24, 'lib/thumbyLogo.bin',0,0,-1)
@@ -67,9 +67,7 @@ gamesBMonly +=bytearray([65,93,85,69,69,127,67,65,117,65,67,127,65,65,115,103,11
 settingsHeader = thumby.Sprite(46, 7, settingsBMonly,key=-1)
 gamesHeader = thumby.Sprite(32, 7, gamesBMonly,key=-1)
 
-#thumbySplash = thumby.sprite(30, 30, 'bird.bin',0,0,-1)
-
-thumby.display.setFPS(100)
+thumby.display.setFPS(50)
 
 thumbySplash.y = -37
 while thumbySplash.y < 5:
@@ -79,8 +77,6 @@ while thumbySplash.y < 5:
     thumby.display.drawSprite(thumbySplash)
     thumby.display.drawSprite(TCSplash)
     thumby.display.update()
-    
-thumby.display.setFPS(50)
 
 thumbyLogoHeight=thumbySplash.y
 

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -3,7 +3,7 @@ from machine import freq
 freq(250_000_000)
 from time import ticks_ms, ticks_us
 from os import listdir, stat
-from gc import 
+from gc import collect
 import thumby
 freq(48_000_000)
 thumby.display.setFont('lib/font5x7.bin', 5, 7, 1)

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,4 +1,4 @@
-# Last updated 14-Dec-2022
+# Last updated 17-Dec-2022
 
 from machine import freq
 freq(250_000_000)
@@ -12,7 +12,7 @@ thumby.display.setFont('lib/font5x7.bin', 5, 7, 1)
 try:
     conf = open("thumby.cfg", "r").read().split(',')
     if(len(conf)<6):
-        conf.append(',brightness,2')
+        conf.append(',brightness,1')
 except OSError:
     conf = open("thumby.cfg", "w")
     conf.write("audioenabled,1,lastgame,/Games/TinyBlocks/TinyBlocks.py,brightness,1")
@@ -44,7 +44,7 @@ audioSetting=int(getConfigSetting("audioenabled"))
 brightnessSetting=int(getConfigSetting("brightness"))
 audioSettings=['Audio: Off', 'Audio:  On']
 brightnessSettings=['Brite: Low', 'Brite: Mid', 'Brite:  Hi']
-brightnessVals=[0,28,127]
+brightnessVals=[1,28,127]
 settings=[audioSettings[audioSetting], brightnessSettings[brightnessSetting]]
 
 

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -2,8 +2,8 @@
 from machine import freq
 freq(250_000_000)
 from time import ticks_ms, ticks_us
-import os
-import gc
+from os import listdir, stat
+from gc import 
 import thumby
 freq(48_000_000)
 thumby.display.setFont('lib/font5x7.bin', 5, 7, 1)
@@ -96,12 +96,12 @@ xScrollPos=0
 xScrollTarget=0
 
 selpos = -1
-files = os.listdir("/Games")
+files = listdir("/Games")
 selected = False
 scroll = 0
 
 for k in range(len(files)):
-    if(os.stat("/Games/"+files[k])[0] != 16384):
+    if(stat("/Games/"+files[k])[0] != 16384):
         files[k] = ""
 try:
     while(True):
@@ -117,10 +117,8 @@ for k in range(len(shortFiles)):
 settingsSelpos = -1
 SettingsScroll = 0
 
-#print(gc.mem_free())
-#print(gc.collect())
-#print(gc.mem_free())
-
+# garbage collection
+collect()
 
 def writeCenteredText(text, x, y ,color):
     textLen = min(len(text),10)

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -141,7 +141,6 @@ def drawBracketsAround(text, x, y ,color):
     if(color):
         thumby.display.blit(rightArrowBA, xc-1, y+1, 3, 5,-1,0,0)
     xc=x +(textLen * 6) // 2 +2
-    #x=min(x,70)
     if(color):
         thumby.display.blit(leftArrowBA, xc-1, y+1, 3, 5,-1,0,0)
 lastPosition=0
@@ -266,10 +265,8 @@ while True:
         if(selpos<2):
             selectOffset = selpos*8+8
             
-        #thumby.display.blit(gamesBM, xScrollPos + 72//2 - 32//2 +1, max(0,yScrollPos+40), 32, 7, -1,0,0)
         gamesHeader.x= xScrollPos + 72//2 - 32//2 +1
         gamesHeader.y= max(0,yScrollPos+40)
-        #gamesHeader.setFrame( frameCounter%2)
         thumby.display.drawSprite(gamesHeader)
         
         if(ticks_ms() % 1000 < 500 and selpos<0 and yScrollTarget == -40 and xScrollTarget == 0):
@@ -290,7 +287,6 @@ while True:
         if(ticks_ms() % 1000 < 500 and settingsSelpos>=0):
             drawBracketsAround(settings[settingsSelpos], 72+xScrollPos + thumby.display.width//2, yScrollPos+40+selectOffset+scrollDisplayed, 1)
         
-        #thumby.display.blit(settingsBM, 72+xScrollPos + 72//2 - 46//2 +1, max(0,yScrollPos+40), 46, 7, -1,0,0)
         settingsHeader.x=72+xScrollPos + 72//2 - 46//2 +1
         settingsHeader.y=max(0,yScrollPos+40)
         thumby.display.drawSprite(settingsHeader)
@@ -367,13 +363,6 @@ while True:
     
     
     thumby.display.update()
-#     frameTimeRemaining = 28-(ticks_us() - start)//1000
-#     if(frameTimeRemaining>0):
-#         sleep_ms(frameTimeRemaining)
-#         
-    #print(ticks_us() - start)
-    #machine.idle()
-    #sleep_ms(100)
     frameCounter+=1
     
     if(thumby.inputJustPressed()):
@@ -440,9 +429,6 @@ while True:
                         thumby.display.brightness(brightnessVals[brightnessSetting])
                         saveConfigSetting("brightness", str(brightnessSetting))
                     settings=[audioSettings[audioSetting], brightnessSettings[brightnessSetting]]
-        #print(ticks_us() - start)
-
-
 
 
 machine.reset()

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,7 +1,7 @@
 
 from machine import freq
 freq(250_000_000)
-from time import ticks_ms, ticks_us
+from time import ticks_ms, ticks_us, sleep_ms
 from os import listdir, stat
 from gc import collect
 import thumby
@@ -326,8 +326,7 @@ while True:
             creditsScrollOffset = (creditsScrollPosition)%(width)
             xScrollTarget = -216
             noButtonPress = True
-            from machine import lightsleep
-            lightsleep(100)
+            sleep_ms(100)
                     
     if(xScrollPos<-144 or (xScrollTarget==-72 and xScrollPos<-72)):
         if(xScrollPos==-216):

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,14 +1,13 @@
-# Last updated 17-Dec-2022
+# Last updated 23-Dec-2022
 
 from machine import freq
 freq(250_000_000)
 from machine import mem32, soft_reset
-from time import ticks_ms, ticks_us, sleep_ms
+from time import ticks_ms, sleep_ms
 from os import listdir, stat
 from gc import collect as gc_collect
 import thumby
 freq(48_000_000)
-thumby.display.setFont('lib/font5x7.bin', 5, 7, 1)
 
 try:
     conf = open("thumby.cfg", "r").read().split(',')
@@ -64,7 +63,7 @@ thumbySplash=thumby.Sprite(72, 24, 'lib/thumbyLogo.bin',0,0,-1)
 
 settingsBMonly = bytearray([81,81,85,69,69,127,65,65,85,85,93,127,125,65,65,125,127,125,65,65,125,127,93,65,65,93,127,65,65,115,103,65,65,127,65,65,93,85,69,69,127,81,81,85,69,69])
 gamesBMonly =bytearray([65,65,93,85,69,69,127,67,65,117,65,67,127,65,65,115,103,115,65,65,127,65,65,85,85,93,127,81,81,85,69,69])
-gamesBMonly +=bytearray([65,93,85,69,69,127,67,65,117,65,67,127,65,65,115,103,115,65,65,127,65,65,85,85,93,127,81,81,85,69,69,0xFF])
+
 
 settingsHeader = thumby.Sprite(46, 7, settingsBMonly,key=-1)
 gamesHeader = thumby.Sprite(32, 7, gamesBMonly,key=-1)
@@ -73,7 +72,7 @@ thumby.display.setFPS(50)
 
 thumbySplash.y = -37
 while thumbySplash.y < 5:
-    thumbySplash.y += 1
+    thumbySplash.y += 2
     TCSplash.y=thumbySplash.y+37
     thumby.display.fill(0)
     thumby.display.drawSprite(thumbySplash)
@@ -197,7 +196,6 @@ def launchGame():
 
 while True:
     thumbySplash.setFrame(thumbySplash.currentFrame+1)
-    start = ticks_us()
     if(yScrollTarget!=yScrollPos):
         if(yScrollTarget>yScrollPos):
             yScrollPos += 1

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,3 +1,4 @@
+# Last updated 14-Dec-2022
 
 from machine import freq
 freq(250_000_000)

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,4 +1,4 @@
-# Last updated 29-Dec-2022
+# Last updated 8-Jan-2023
 
 from machine import freq
 freq(250_000_000)
@@ -421,4 +421,4 @@ while True:
                     settings=[audioSettings[audioSetting], brightnessSettings[brightnessSetting]]
 
 
-machine.reset()
+thumby.reset()

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,4 +1,4 @@
-# Last updated 23-Dec-2022
+# Last updated 29-Dec-2022
 
 from machine import freq
 freq(250_000_000)
@@ -190,7 +190,7 @@ def launchGame():
     if(selpos>=0):
         gamePath="/Games/"+files[selpos]+"/"+files[selpos]+".py"
         saveConfigSetting("lastgame", gamePath)
-    mem32[0x4005800C]=1 # Watchdog timer scratch register
+    mem32[0x4005800C]=1 # WDT scratch register '0'
     soft_reset()
 
 

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -332,7 +332,7 @@ while True:
             creditsScrollOffset = (creditsScrollPosition)%(width)
             xScrollTarget = -216
             noButtonPress = True
-            sleep_ms(100)
+            machine.lightsleep(100)
                     
     if(xScrollPos<-144 or (xScrollTarget==-72 and xScrollPos<-72)):
         if(xScrollPos==-216):

--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -1,11 +1,11 @@
 
 from machine import freq
-freq(125000000)
-from time import sleep_ms, ticks_ms, sleep_us, ticks_us
+freq(125_000_000)
+from time import sleep_ms, ticks_ms, ticks_us
 import os
 import gc
 import thumby
-freq(48000000)
+freq(48_000_000)
 thumby.display.setFont('lib/font5x7.bin', 5, 7, 1)
 
 try:

--- a/js/play.js
+++ b/js/play.js
@@ -244,10 +244,10 @@ else {
         var data = new TextDecoder("utf-8").decode(new Uint8Array(await response.arrayBuffer()));
         // Patch the menu to work in the emulator
         data = data.replace(
-            'files = os.listdir("/Games")',
+            'files = listdir("/Games")',
             `files = """${games.join("\n")}""".split("\\n")`)
         data = data.replace(
-            'os.stat("/Games/"+files[k])[0] != 16384',
+            'stat("/Games/"+files[k])[0] != 16384',
             'False');
         data = data.replace(
             'machine.mem32[SCRATCH0_ADDR]=1',

--- a/js/play.js
+++ b/js/play.js
@@ -250,7 +250,7 @@ else {
             'stat("/Games/"+files[k])[0] != 16384',
             'False');
         data = data.replace(
-            'machine.mem32[SCRATCH0_ADDR]=1',
+            'mem32[0x4005800C]=1',
             'print(f"HEYTHUMBY!LOAD:{files[selpos] if selpos >=0 else ""}")')
         new EditorWrapper(conta, {
             "id": "PlayerEditorMenu",


### PR DESCRIPTION
The `main.py` and `menu.py` should be lean. 🗜💪

Small tweaks to clean things up. Mainly trimming unused imports.
Tested and looks ok. (Thanks @fuglaro for extensive review and testing).

### Speed
Benchmarked with `ticks_ms`:  
`main.py` boot reduced from ~754ms to ~246ms (now takes ~1/3rd of the time!). 
`menu.py` up to main loop, reduced from ~1766ms to ~1581ms.

### Memory
Memory savings using `print(gc.mem_free())`:
**Vanilla**
Before GC: mem_free=81376
After GC: mem_free=122112
**This PR** 
Before GC: mem_free=84288  (+2,912 bytes free) ~2.8kb!!
After GC: mem_free=122144  (+32 bytes free) - the GC was managing to remove all the unused imports pretty well.