### PR TITLE
Replaced emulator-player mode hot patches with updates to menu.py

### DIFF
--- a/ThumbyGames/menu.py
+++ b/ThumbyGames/menu.py
@@ -97,13 +97,21 @@ xScrollPos=0
 xScrollTarget=0
 
 selpos = -1
-files = listdir("/Games")
+try:
+    files = listdir("/Games")
+except OSError:
+    # Games folder missing, assume emulation mode.
+    with open('/__Games__', 'r') as games:
+        files = games.readlines()
 selected = False
 scroll = 0
 
 for k in range(len(files)):
-    if(stat("/Games/"+files[k])[0] != 16384):
-        files[k] = ""
+    try:
+        if(stat("/Games/"+files[k])[0] != 16384):
+            files[k] = ""
+    except OSError:
+        pass # File missing, which is expected in emulation mode
 try:
     while(True):
         files.remove("")
@@ -191,6 +199,8 @@ def launchGame():
         gamePath="/Games/"+files[selpos]+"/"+files[selpos]+".py"
         saveConfigSetting("lastgame", gamePath)
     mem32[0x4005800C]=1 # WDT scratch register '0'
+    # In case emulating, inform the emulator to load the game.
+    print(f"HEYTHUMBY!LOAD:{files[selpos] if selpos >=0 else ""}")
     soft_reset()
 
 


### PR DESCRIPTION
The stand-alone emulator previously used the same menu.py file that runs on the device, but manipulated the python code with some hot patches to be able to dynamically load all the games from the Arcade.

This change avoids this hot patching by making some minimal fallback behaviour in menu.py:

* If there is an error listing the contents of `/Games/`, menu.py will load the list of games from a `/__Games__' file, which is provided by the standalone emulator.
* If running `stat` on the game file errors, assume we are running in emulatton mode and ignore it.
* When a game is launched, print to terminal a line like `HEYTHUMBY!LOAD:TinyBlocks`

There is also a related change in play.js that cleans up better when games end and it goes back to the menu. Previously, lots of hidden Editor widgets would be left open.

There should be no other behavioural changes with this update expect code that is less brittle to future changes.

Tests on the the following looked good to me:
* standalone emulator via menu
* standalone emulator via direct link
* code editor emulator
* fast execute
* thumby device