### PR TITLE
Fix emulator hanging for thumbySaves.saveData.getItem and delItem

### DIFF
--- a/ThumbyGames/lib-emulator/thumbySaves.py
+++ b/ThumbyGames/lib-emulator/thumbySaves.py
@@ -93,7 +93,6 @@ class SavesClass:
             self.volatileDict.update({key:value})
     
     # Get entry from volatile dictionary
-    @micropython.native
     def getItem(self, key):
         ret = self.volatileDict.get(key, None)
         if ret == None:
@@ -104,7 +103,6 @@ class SavesClass:
         return ret
     
     # Delete entry in volatile dictionary
-    @micropython.viper
     def delItem(self, key):
         try:
             return self.volatileDict.pop(key)


### PR DESCRIPTION
FIXES #62 

micropython.native. For this code:
```python
@micropython.native
def hang():
    try:
        pass
    except:
        pass

print(1)
hang()
print(2) # Never shows
```
I get this when running in FAST EXECUTE:
```
>>> 
1
2
>
```
BUT this when running in the emulator?!?!?!
```
>>> __import__('/sdfsdfsd')
1

```