### PR TITLE
Add -1 color parameter to set pixel for 'toggle pixel'

### DIFF
--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -108,6 +108,8 @@ class GraphicsClass:
             buf[(y >> 3) * screenWidth + x] |= 1 << (y & 0x07)
         elif(color==int(0)):
             buf[(y >> 3) * screenWidth + x] &= 0xff ^ (1 << (y & 0x07))
+        elif(color==int(-1)):
+            buf[(y >> 3) * screenWidth + x] ^= 1 << (y & 0x07)
 
     
     @micropython.viper


### PR DESCRIPTION
Added one more ability to thumby.display.setPixel(), by using parameter -1 you can toggle the existing pixel at the provided X Y coordinates.