### PR TITLE
Add -2 color and key to several graphic functions for inverting pixels

### DIFF
--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -1,4 +1,5 @@
 # Thumby graphics base
+# - Emulator edition
 
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
 # 11-Jul-2022
@@ -25,6 +26,7 @@ from os import stat
 from time import ticks_ms, ticks_diff, sleep_ms
 from thumbyHardware import i2c, spi
 from thumbyButton import buttonA, buttonB, buttonU, buttonD, buttonL, buttonR
+import emulator
 
 # Last updated 15-Dec-2022
 __version__ = '1.9'
@@ -33,6 +35,7 @@ __version__ = '1.9'
 class GraphicsClass:
     def __init__(self, display, width, height):
         self.display = display
+        self.initEmuScreen()
         self.width = width
         self.height = height
         self.max_x = width-1
@@ -41,6 +44,10 @@ class GraphicsClass:
         self.lastUpdateEnd = 0
         self.setFont('lib/font5x7.bin', 5, 7, 1)
         self.fill(0)
+        
+    @micropython.viper
+    def initEmuScreen(self):
+        emulator.screen_breakpoint(ptr16(self.display.buffer))
 
     @micropython.native
     def setFont(self, fontFile, width, height, space):
@@ -82,6 +89,7 @@ class GraphicsClass:
             setting=127
         if(setting<0):
             setting=0
+        emulator.brightness_breakpoint(setting)
         self.display.contrast(setting)
 
     # Fill the buffer with a given color.
@@ -93,7 +101,7 @@ class GraphicsClass:
                 buf[int(i)]=0
         elif int(color)==int(-2):
             for i in range(int(len(self.display.buffer))):
-                buf[i] ^= 0xff                
+                buf[i] ^= 0xff
         else:
             for i in range(int(len(self.display.buffer))):
                 buf[i]=0xff
@@ -112,7 +120,7 @@ class GraphicsClass:
         elif(color==int(0)):
             buf[(y >> 3) * screenWidth + x] &= 0xff ^ (1 << (y & 0x07))
         elif(color==int(-2)):
-            buf[(y >> 3) * screenWidth + x] ^= 1 << (y & 0x07)
+            buf[(y >> 3) * screenWidth + x] ^= 1 << (y & 0x07)                                                                  
 
     
     @micropython.viper
@@ -190,7 +198,7 @@ class GraphicsClass:
                 buf[(y2 >> 3) * screenWidth + x2] |= 1 << (y2 & 0x07)
             elif(color==int(0)):
                 buf[(y2 >> 3) * screenWidth + x2] &= 0xff ^ (1 << (y2 & 0x07))
-            elif(color==int(-2)):
+                    elif(color==int(-2)): 
                 buf[(y2 >> 3) * screenWidth + x2] ^= 1 << (y2 & 0x07)
 
     @micropython.viper
@@ -397,7 +405,7 @@ class GraphicsClass:
         if xStart+width>72:
             blitWidth = 72-xStart
         y=yFirst
-        if(key==key): # ignore key value?
+        if(key==key):#ignore key value?
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:
@@ -412,10 +420,10 @@ class GraphicsClass:
     @micropython.native
     def drawSpriteWithMask(self, s, m):
         self.blitWithMask(s.bitmap, int(s.x), int(s.y), s.width, s.height, s.key, s.mirrorX, s.mirrorY, m.bitmap)
-
+        
 # Graphics instantiation
-if(spi):
-    display = GraphicsClass(SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
-else:
-    from ssd1306 import SSD1306_I2C
-    display = GraphicsClass(SSD1306_I2C(72, 40, i2c, res=Pin(18)), 72, 40)
+        
+display = GraphicsClass(SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
+     
+                                   
+                                                                          

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -91,6 +91,9 @@ class GraphicsClass:
         if int(color)==int(0):
             for i in range(int(len(self.display.buffer))):
                 buf[int(i)]=0
+        elif int(color)==int(-2):
+            for i in range(int(len(self.display.buffer))):
+                buf[i] ^= 0xff                
         else:
             for i in range(int(len(self.display.buffer))):
                 buf[i]=0xff

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -33,6 +33,12 @@ __version__ = '1.9'
 
 # Graphics class, from which the gfx namespace is defined.
 class GraphicsClass:
+    
+    BLACK     = 0
+    WHITE     = 1
+    TOGGLE    =-2
+    NOKEY     = 1
+    
     def __init__(self, display, width, height):
         self.display = display
         self.initEmuScreen()

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -293,7 +293,7 @@ class GraphicsClass:
                         xFirst=0
                     if xStart+textWidth>72:
                         blitWidth = 72-xStart
-                    if(int(color)==int(0)):
+                    if(int(color)==int(self.BLACK)):
                         while yb < blitHeight:
                             x=xFirst
                             while x < blitWidth:
@@ -301,7 +301,7 @@ class GraphicsClass:
                                     ptr[((yStart+yb) >> 3) * screenWidth + xStart+x] &= 0xff ^ (1 << (yStart+yb & 0x07))
                                 x+=1
                             yb+=1
-                    elif(int(color)==int(-2)):
+                    elif(int(color)==int(self.TOGGLE)):
                         while yb < blitHeight:
                             x=xFirst
                             while x < blitWidth:

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -1,5 +1,4 @@
 # Thumby graphics base
-# - Emulator edition
 
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
 # 11-Jul-2022
@@ -26,7 +25,6 @@ from os import stat
 from time import ticks_ms, ticks_diff, sleep_ms
 from thumbyHardware import i2c, spi
 from thumbyButton import buttonA, buttonB, buttonU, buttonD, buttonL, buttonR
-import emulator
 
 # Last updated 15-Dec-2022
 __version__ = '1.9'
@@ -35,7 +33,6 @@ __version__ = '1.9'
 class GraphicsClass:
     def __init__(self, display, width, height):
         self.display = display
-        self.initEmuScreen()
         self.width = width
         self.height = height
         self.max_x = width-1
@@ -44,10 +41,6 @@ class GraphicsClass:
         self.lastUpdateEnd = 0
         self.setFont('lib/font5x7.bin', 5, 7, 1)
         self.fill(0)
-        
-    @micropython.viper
-    def initEmuScreen(self):
-        emulator.screen_breakpoint(ptr16(self.display.buffer))
 
     @micropython.native
     def setFont(self, fontFile, width, height, space):
@@ -89,7 +82,6 @@ class GraphicsClass:
             setting=127
         if(setting<0):
             setting=0
-        emulator.brightness_breakpoint(setting)
         self.display.contrast(setting)
 
     # Fill the buffer with a given color.
@@ -116,6 +108,8 @@ class GraphicsClass:
             buf[(y >> 3) * screenWidth + x] |= 1 << (y & 0x07)
         elif(color==int(0)):
             buf[(y >> 3) * screenWidth + x] &= 0xff ^ (1 << (y & 0x07))
+        elif(color==int(-2)):
+            buf[(y >> 3) * screenWidth + x] ^= 1 << (y & 0x07)
 
     
     @micropython.viper
@@ -171,12 +165,17 @@ class GraphicsClass:
                         buf[(x1 >> 3) * screenWidth + y1] |= 1 << (x1 & 0x07)
                     elif(color==int(0)):
                         buf[(x1 >> 3) * screenWidth + y1] &= 0xff ^ (1 << (x1 & 0x07))
+                    elif(color==int(-2)):
+                        buf[(x1 >> 3) * screenWidth + y1] ^= 1 << (x1 & 0x07)
             else:
                 if (0 <= x1 and x1 < screenWidth and 0 <= y1 and y1 < screenHeight):
                     if(color==int(1)):
                         buf[(y1 >> 3) * screenWidth + x1] |= 1 << (y1 & 0x07)
                     elif(color==int(0)):
                         buf[(y1 >> 3) * screenWidth + x1] &= 0xff ^ (1 << (y1 & 0x07))
+                    elif(color==int(-2)):
+                        buf[(y1 >> 3) * screenWidth + x1] ^= 1 << (y1 & 0x07)
+                    
             while (e >= 0) :
                 y1 += sy
                 e -= 2 * dx
@@ -188,6 +187,8 @@ class GraphicsClass:
                 buf[(y2 >> 3) * screenWidth + x2] |= 1 << (y2 & 0x07)
             elif(color==int(0)):
                 buf[(y2 >> 3) * screenWidth + x2] &= 0xff ^ (1 << (y2 & 0x07))
+            elif(color==int(-2)):
+                buf[(y2 >> 3) * screenWidth + x2] ^= 1 << (y2 & 0x07)
 
     @micropython.viper
     def drawRectangle(self, x:int, y:int, width:int, height:int, color:int):
@@ -232,6 +233,13 @@ class GraphicsClass:
                     buf[(y >> 3) * screenWidth + px] &= 0xff ^ (1 << (y & 0x07))
                     px+=1
                 y+=1
+        elif(color==int(-2)):
+            while y < yMax:
+                px=x
+                while px < x+width+1:
+                    buf[(y >> 3) * screenWidth + px] ^= 1 << (y & 0x07)
+                    px+=1
+                y+=1
 
     # Draw a string with top left corner (x, y) in a given color.
     @micropython.viper
@@ -274,6 +282,14 @@ class GraphicsClass:
                             while x < blitWidth:
                                 if(sprtptr[(yb >> 3) * textWidth + x] & (1 << (yb & 0x07))):
                                     ptr[((yStart+yb) >> 3) * screenWidth + xStart+x] &= 0xff ^ (1 << (yStart+yb & 0x07))
+                                x+=1
+                            yb+=1
+                    elif(int(color)==int(-2)):
+                        while yb < blitHeight:
+                            x=xFirst
+                            while x < blitWidth:
+                                if(sprtptr[(yb >> 3) * textWidth + x] & (1 << (yb & 0x07))):
+                                    ptr[((yStart+yb) >> 3) * screenWidth + xStart+x] ^= 1 << ((yStart+yb) & 0x07)
                                 x+=1
                             yb+=1
                     else:
@@ -330,6 +346,14 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] &= 0xff ^ (1 << ((yStart+y) & 0x07))
                     x+=1
                 y+=1
+        elif(key==-2):
+            while y < blitHeight:
+                x=xFirst
+                while x < blitWidth:
+                    if(sprtptr[((height-1-y if mirrorY==1 else y) >> 3) * width + (width-1-x if mirrorX==1 else x)] & (1 << ((height-1-y if mirrorY==1 else y) & 0x07))):
+                        ptr[((yStart+y) >> 3) * screenWidth + xStart+x] ^= 1 << ((yStart+y) & 0x07)
+                    x+=1
+                y+=1
         else:
             while y < blitHeight:
                 x=xFirst
@@ -370,7 +394,7 @@ class GraphicsClass:
         if xStart+width>72:
             blitWidth = 72-xStart
         y=yFirst
-        if(key==key):#ignore key value?
+        if(key==key): # ignore key value?
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:
@@ -385,6 +409,10 @@ class GraphicsClass:
     @micropython.native
     def drawSpriteWithMask(self, s, m):
         self.blitWithMask(s.bitmap, int(s.x), int(s.y), s.width, s.height, s.key, s.mirrorX, s.mirrorY, m.bitmap)
-        
+
 # Graphics instantiation
-display = GraphicsClass(SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
+if(spi):
+    display = GraphicsClass(SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
+else:
+    from ssd1306 import SSD1306_I2C
+    display = GraphicsClass(SSD1306_I2C(72, 40, i2c, res=Pin(18)), 72, 40)

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -371,7 +371,7 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] ^= 1 << ((yStart+y) & 0x07)
                     x+=1
                 y+=1
-        else: # key==self.NOKEY
+        else: # when key==self.NOKEY
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -371,7 +371,7 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] ^= 1 << ((yStart+y) & 0x07)
                     x+=1
                 y+=1
-        else:
+        else: # key==self.NOKEY
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:

--- a/ThumbyGames/lib-emulator/thumbyGraphics.py
+++ b/ThumbyGames/lib-emulator/thumbyGraphics.py
@@ -37,7 +37,7 @@ class GraphicsClass:
     BLACK     = 0
     WHITE     = 1
     TOGGLE    =-2
-    NOKEY     = 1
+    NOKEY     =-1
     
     def __init__(self, display, width, height):
         self.display = display
@@ -102,10 +102,10 @@ class GraphicsClass:
     @micropython.viper
     def fill(self, color:int):
         buf = ptr8(self.display.buffer)
-        if int(color)==int(0):
+        if int(color)==int(self.BLACK):
             for i in range(int(len(self.display.buffer))):
                 buf[int(i)]=0
-        elif int(color)==int(-2):
+        elif int(color)==int(self.TOGGLE):
             for i in range(int(len(self.display.buffer))):
                 buf[i] ^= 0xff
         else:
@@ -121,11 +121,11 @@ class GraphicsClass:
         if not 0<=y<screenHeight:
             return
         buf = ptr8(self.display.buffer)
-        if(color==int(1)):
+        if(color==int(self.WHITE)):
             buf[(y >> 3) * screenWidth + x] |= 1 << (y & 0x07)
-        elif(color==int(0)):
+        elif(color==int(self.BLACK)):
             buf[(y >> 3) * screenWidth + x] &= 0xff ^ (1 << (y & 0x07))
-        elif(color==int(-2)):
+        elif(color==int(self.TOGGLE)):
             buf[(y >> 3) * screenWidth + x] ^= 1 << (y & 0x07)                                                                  
 
     
@@ -178,19 +178,19 @@ class GraphicsClass:
         for i in range(dx):
             if (steep):
                 if (0 <= y1 and y1 < screenWidth and 0 <= x1 and x1 < screenHeight):
-                    if(color==int(1)):
+                    if(color==int(self.WHITE)):
                         buf[(x1 >> 3) * screenWidth + y1] |= 1 << (x1 & 0x07)
-                    elif(color==int(0)):
+                    elif(color==int(self.BLACK)):
                         buf[(x1 >> 3) * screenWidth + y1] &= 0xff ^ (1 << (x1 & 0x07))
-                    elif(color==int(-2)):
+                    elif(color==int(self.TOGGLE)):
                         buf[(x1 >> 3) * screenWidth + y1] ^= 1 << (x1 & 0x07)
             else:
                 if (0 <= x1 and x1 < screenWidth and 0 <= y1 and y1 < screenHeight):
-                    if(color==int(1)):
+                    if(color==int(self.WHITE)):
                         buf[(y1 >> 3) * screenWidth + x1] |= 1 << (y1 & 0x07)
-                    elif(color==int(0)):
+                    elif(color==int(self.BLACK)):
                         buf[(y1 >> 3) * screenWidth + x1] &= 0xff ^ (1 << (y1 & 0x07))
-                    elif(color==int(-2)):
+                    elif(color==int(self.TOGGLE)):
                         buf[(y1 >> 3) * screenWidth + x1] ^= 1 << (y1 & 0x07)
                     
             while (e >= 0) :
@@ -200,11 +200,11 @@ class GraphicsClass:
             e += 2 * dy
 
         if (0 <= x2 and x2 < screenWidth and 0 <= y2 and y2 < screenHeight):
-            if(color==int(1)):
+            if(color==int(self.WHITE)):
                 buf[(y2 >> 3) * screenWidth + x2] |= 1 << (y2 & 0x07)
-            elif(color==int(0)):
+            elif(color==int(self.BLACK)):
                 buf[(y2 >> 3) * screenWidth + x2] &= 0xff ^ (1 << (y2 & 0x07))
-                    elif(color==int(-2)): 
+                    elif(color==int(self.TOGGLE)): 
                 buf[(y2 >> 3) * screenWidth + x2] ^= 1 << (y2 & 0x07)
 
     @micropython.viper
@@ -236,21 +236,21 @@ class GraphicsClass:
         buf = ptr8(self.display.buffer)
         yMax=y+height+1
         screenWidth=int(self.width)
-        if(color==int(1)):
+        if(color==int(self.WHITE)):
             while y < yMax:
                 px=x
                 while px < x+width+1:
                     buf[(y >> 3) * screenWidth + px] |= 1 << (y & 0x07)
                     px+=1
                 y+=1
-        elif(color==int(0)):
+        elif(color==int(self.BLACK)):
             while y < yMax:
                 px=x
                 while px < x+width+1:
                     buf[(y >> 3) * screenWidth + px] &= 0xff ^ (1 << (y & 0x07))
                     px+=1
                 y+=1
-        elif(color==int(-2)):
+        elif(color==int(self.TOGGLE)):
             while y < yMax:
                 px=x
                 while px < x+width+1:
@@ -347,7 +347,7 @@ class GraphicsClass:
             blitWidth = screenWidth-xStart
         
         y=yFirst
-        if(key==0):
+        if(key==int(self.BLACK)):
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:
@@ -355,7 +355,7 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] |= 1 << ((yStart+y) & 0x07)
                     x+=1
                 y+=1
-        elif(key==1):
+        elif(key==int(self.WHITE)):
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:
@@ -363,7 +363,7 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] &= 0xff ^ (1 << ((yStart+y) & 0x07))
                     x+=1
                 y+=1
-        elif(key==-2):
+        elif(key==int(self.TOGGLE)):
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -1,6 +1,7 @@
 # Thumby graphics base
+
 # Written by Mason Watmough, Jason Marcum, and Ben Rose for TinyCircuits.
-# Last edited 7/11/2022
+# 11-Jul-2022
 
 '''
     This file is part of the Thumby API.
@@ -18,14 +19,14 @@
     the Thumby API. If not, see <https://www.gnu.org/licenses/>.
 '''
 
-import ssd1306
+from ssd1306 import SSD1306_SPI
 from machine import Pin
 from os import stat
 from time import ticks_ms, ticks_diff, sleep_ms
 from thumbyHardware import i2c, spi
 from thumbyButton import buttonA, buttonB, buttonU, buttonD, buttonL, buttonR
 
-# Last updated 11/11/2022 for menu reset change
+# Last updated 15-Dec-2022
 __version__ = '1.9'
 
 # Graphics class, from which the gfx namespace is defined.
@@ -39,7 +40,6 @@ class GraphicsClass:
         self.frameRate = 0
         self.lastUpdateEnd = 0
         self.setFont('lib/font5x7.bin', 5, 7, 1)
-        #self.setFont('lib/font8x8.bin', 8, 8, 0)
         self.fill(0)
 
     @micropython.native
@@ -175,7 +175,7 @@ class GraphicsClass:
                         buf[(y1 >> 3) * screenWidth + x1] &= 0xff ^ (1 << (y1 & 0x07))
                     elif(color==int(-2)):
                         buf[(y1 >> 3) * screenWidth + x1] ^= 1 << (y1 & 0x07)
-                        
+                    
             while (e >= 0) :
                 y1 += sy
                 e -= 2 * dx
@@ -187,6 +187,8 @@ class GraphicsClass:
                 buf[(y2 >> 3) * screenWidth + x2] |= 1 << (y2 & 0x07)
             elif(color==int(0)):
                 buf[(y2 >> 3) * screenWidth + x2] &= 0xff ^ (1 << (y2 & 0x07))
+            elif(color==int(-2)):
+                buf[(y2 >> 3) * screenWidth + x2] ^= 1 << (y2 & 0x07)
 
     @micropython.viper
     def drawRectangle(self, x:int, y:int, width:int, height:int, color:int):
@@ -282,6 +284,14 @@ class GraphicsClass:
                                     ptr[((yStart+yb) >> 3) * screenWidth + xStart+x] &= 0xff ^ (1 << (yStart+yb & 0x07))
                                 x+=1
                             yb+=1
+                    elif(int(color)==int(-2)):
+                        while yb < blitHeight:
+                            x=xFirst
+                            while x < blitWidth:
+                                if(sprtptr[(yb >> 3) * textWidth + x] & (1 << (yb & 0x07))):
+                                    ptr[((yStart+yb) >> 3) * screenWidth + xStart+x] ^= 1 << ((yStart+yb) & 0x07)
+                                x+=1
+                            yb+=1
                     else:
                         while yb < blitHeight:
                             x=xFirst
@@ -340,8 +350,8 @@ class GraphicsClass:
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:
-                    if(sprtptr[((height-1-y if mirrorY==1 else y) >> 3) * width + (width-1-x if mirrorX==1 else x)] & (1 << ((height-1-y if mirrorY==1 else y) & 0x07))==0):
-                        ptr[((yStart+y) >> 3) * screenWidth + xStart+x] ^= 0xff ^ (1 << ((yStart+y) & 0x07))
+                    if(sprtptr[((height-1-y if mirrorY==1 else y) >> 3) * width + (width-1-x if mirrorX==1 else x)] & (1 << ((height-1-y if mirrorY==1 else y) & 0x07))):
+                        ptr[((yStart+y) >> 3) * screenWidth + xStart+x] ^= 1 << ((yStart+y) & 0x07)
                     x+=1
                 y+=1
         else:
@@ -383,9 +393,8 @@ class GraphicsClass:
             xFirst=0
         if xStart+width>72:
             blitWidth = 72-xStart
-        #print(y, yFirst, blitHeight, height)
         y=yFirst
-        if(key==key):#ignore key value?
+        if(key==key): # ignore key value?
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:
@@ -400,10 +409,10 @@ class GraphicsClass:
     @micropython.native
     def drawSpriteWithMask(self, s, m):
         self.blitWithMask(s.bitmap, int(s.x), int(s.y), s.width, s.height, s.key, s.mirrorX, s.mirrorY, m.bitmap)
-        
+
 # Graphics instantiation
-display=None
-if(i2c):
-    display = GraphicsClass(ssd1306.SSD1306_I2C(72, 40, i2c, res=Pin(18)), 72, 40)
 if(spi):
-    display = GraphicsClass(ssd1306.SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
+    display = GraphicsClass(SSD1306_SPI(72, 40, spi, dc=Pin(17), res=Pin(20), cs=Pin(16)), 72, 40)
+else:
+    from ssd1306 import SSD1306_I2C
+    display = GraphicsClass(SSD1306_I2C(72, 40, i2c, res=Pin(18)), 72, 40)

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -31,6 +31,12 @@ __version__ = '1.9'
 
 # Graphics class, from which the gfx namespace is defined.
 class GraphicsClass:
+    
+    BLACK     = 0
+    WHITE     = 1
+    TOGGLE    =-2
+    NOKEY     = 1
+    
     def __init__(self, display, width, height):
         self.display = display
         self.width = width
@@ -41,7 +47,7 @@ class GraphicsClass:
         self.lastUpdateEnd = 0
         self.setFont('lib/font5x7.bin', 5, 7, 1)
         self.fill(0)
-
+    
     @micropython.native
     def setFont(self, fontFile, width, height, space):
         self.textBitmapSource = fontFile

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -363,7 +363,7 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] ^= 1 << ((yStart+y) & 0x07)
                     x+=1
                 y+=1
-        else: # key==self.NOKEY
+        else: # when key==self.NOKEY
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -91,6 +91,9 @@ class GraphicsClass:
         if int(color)==int(0):
             for i in range(int(len(self.display.buffer))):
                 buf[int(i)]=0
+        elif int(color)==int(-2):
+            for i in range(int(len(self.display.buffer))):
+                buf[i] ^= 0xff
         else:
             for i in range(int(len(self.display.buffer))):
                 buf[i]=0xff

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -108,6 +108,8 @@ class GraphicsClass:
             buf[(y >> 3) * screenWidth + x] |= 1 << (y & 0x07)
         elif(color==int(0)):
             buf[(y >> 3) * screenWidth + x] &= 0xff ^ (1 << (y & 0x07))
+        elif(color==int(-1)):
+            buf[(y >> 3) * screenWidth + x] ^= 1 << (y & 0x07)
 
     
     @micropython.viper

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -363,7 +363,7 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] ^= 1 << ((yStart+y) & 0x07)
                     x+=1
                 y+=1
-        else:
+        else: # key==self.NOKEY
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:

--- a/ThumbyGames/lib/thumbyGraphics.py
+++ b/ThumbyGames/lib/thumbyGraphics.py
@@ -32,10 +32,10 @@ __version__ = '1.9'
 # Graphics class, from which the gfx namespace is defined.
 class GraphicsClass:
     
-    BLACK     = 0
-    WHITE     = 1
-    TOGGLE    =-2
-    NOKEY     = 1
+    BLACK     =  0
+    WHITE     =  1
+    TOGGLE    = -2
+    NOKEY     = -1
     
     def __init__(self, display, width, height):
         self.display = display
@@ -94,10 +94,10 @@ class GraphicsClass:
     @micropython.viper
     def fill(self, color:int):
         buf = ptr8(self.display.buffer)
-        if int(color)==int(0):
+        if int(color)==int(self.BLACK):
             for i in range(int(len(self.display.buffer))):
                 buf[int(i)]=0
-        elif int(color)==int(-2):
+        elif int(color)==int(self.TOGGLE):
             for i in range(int(len(self.display.buffer))):
                 buf[i] ^= 0xff
         else:
@@ -113,11 +113,11 @@ class GraphicsClass:
         if not 0<=y<screenHeight:
             return
         buf = ptr8(self.display.buffer)
-        if(color==int(1)):
+        if(color==int(self.WHITE)):
             buf[(y >> 3) * screenWidth + x] |= 1 << (y & 0x07)
-        elif(color==int(0)):
+        elif(color==int(self.BLACK)):
             buf[(y >> 3) * screenWidth + x] &= 0xff ^ (1 << (y & 0x07))
-        elif(color==int(-2)):
+        elif(color==int(self.TOGGLE)):
             buf[(y >> 3) * screenWidth + x] ^= 1 << (y & 0x07)
 
     
@@ -170,19 +170,19 @@ class GraphicsClass:
         for i in range(dx):
             if (steep):
                 if (0 <= y1 and y1 < screenWidth and 0 <= x1 and x1 < screenHeight):
-                    if(color==int(1)):
+                    if(color==int(self.WHITE)):
                         buf[(x1 >> 3) * screenWidth + y1] |= 1 << (x1 & 0x07)
-                    elif(color==int(0)):
+                    elif(color==int(self.BLACK)):
                         buf[(x1 >> 3) * screenWidth + y1] &= 0xff ^ (1 << (x1 & 0x07))
-                    elif(color==int(-2)):
+                    elif(color==int(self.TOGGLE)):
                         buf[(x1 >> 3) * screenWidth + y1] ^= 1 << (x1 & 0x07)
             else:
                 if (0 <= x1 and x1 < screenWidth and 0 <= y1 and y1 < screenHeight):
-                    if(color==int(1)):
+                    if(color==int(self.WHITE)):
                         buf[(y1 >> 3) * screenWidth + x1] |= 1 << (y1 & 0x07)
-                    elif(color==int(0)):
+                    elif(color==int(self.BLACK)):
                         buf[(y1 >> 3) * screenWidth + x1] &= 0xff ^ (1 << (y1 & 0x07))
-                    elif(color==int(-2)):
+                    elif(color==int(self.TOGGLE)):
                         buf[(y1 >> 3) * screenWidth + x1] ^= 1 << (y1 & 0x07)
                     
             while (e >= 0) :
@@ -192,11 +192,11 @@ class GraphicsClass:
             e += 2 * dy
 
         if (0 <= x2 and x2 < screenWidth and 0 <= y2 and y2 < screenHeight):
-            if(color==int(1)):
+            if(color==int(self.WHITE)):
                 buf[(y2 >> 3) * screenWidth + x2] |= 1 << (y2 & 0x07)
-            elif(color==int(0)):
+            elif(color==int(self.BLACK)):
                 buf[(y2 >> 3) * screenWidth + x2] &= 0xff ^ (1 << (y2 & 0x07))
-            elif(color==int(-2)):
+            elif(color==int(self.TOGGLE)):
                 buf[(y2 >> 3) * screenWidth + x2] ^= 1 << (y2 & 0x07)
 
     @micropython.viper
@@ -228,21 +228,21 @@ class GraphicsClass:
         buf = ptr8(self.display.buffer)
         yMax=y+height+1
         screenWidth=int(self.width)
-        if(color==int(1)):
+        if(color==int(self.WHITE)):
             while y < yMax:
                 px=x
                 while px < x+width+1:
                     buf[(y >> 3) * screenWidth + px] |= 1 << (y & 0x07)
                     px+=1
                 y+=1
-        elif(color==int(0)):
+        elif(color==int(self.BLACK)):
             while y < yMax:
                 px=x
                 while px < x+width+1:
                     buf[(y >> 3) * screenWidth + px] &= 0xff ^ (1 << (y & 0x07))
                     px+=1
                 y+=1
-        elif(color==int(-2)):
+        elif(color==int(self.TOGGLE)):
             while y < yMax:
                 px=x
                 while px < x+width+1:
@@ -285,7 +285,7 @@ class GraphicsClass:
                         xFirst=0
                     if xStart+textWidth>72:
                         blitWidth = 72-xStart
-                    if(int(color)==int(0)):
+                    if(int(color)==int(self.BLACK)):
                         while yb < blitHeight:
                             x=xFirst
                             while x < blitWidth:
@@ -293,7 +293,7 @@ class GraphicsClass:
                                     ptr[((yStart+yb) >> 3) * screenWidth + xStart+x] &= 0xff ^ (1 << (yStart+yb & 0x07))
                                 x+=1
                             yb+=1
-                    elif(int(color)==int(-2)):
+                    elif(int(color)==int(self.TOGGLE)):
                         while yb < blitHeight:
                             x=xFirst
                             while x < blitWidth:
@@ -339,7 +339,7 @@ class GraphicsClass:
             blitWidth = screenWidth-xStart
         
         y=yFirst
-        if(key==0):
+        if(key==int(self.BLACK)):
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:
@@ -347,7 +347,7 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] |= 1 << ((yStart+y) & 0x07)
                     x+=1
                 y+=1
-        elif(key==1):
+        elif(key==int(self.WHITE)):
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:
@@ -355,7 +355,7 @@ class GraphicsClass:
                         ptr[((yStart+y) >> 3) * screenWidth + xStart+x] &= 0xff ^ (1 << ((yStart+y) & 0x07))
                     x+=1
                 y+=1
-        elif(key==-2):
+        elif(key==int(self.TOGGLE)):
             while y < blitHeight:
                 x=xFirst
                 while x < blitWidth:


### PR DESCRIPTION
I used -2 for parameter instead of making new function names as:

it's drop-in feature for existing games 
it's similar to -1 meaning draw both pixels in blit (-1 = draw both 1 and 0, -2 = XOR 1)
it probably wont' throw exceptions if a game using this feature happens to gets ran on an older API version
it's terse
Color parameters 2 and 3 are already reserved for greyscale library.

Let me know what you think, thanks!

-Xyvir