### PR TITLE
Change firmware download link and reorganize utilities dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,19 +91,22 @@
                         <div id="IDUtilitesDropdown" uk-dropdown="offset: 0; mode: click; delay-hide: 200">
                             <ul class="uk-nav uk-dropdown-nav">
                                 <li><button id="IDNewGameBTN" title="Generates file structure needed for getting a game to show up on the Thumby start-up screen" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Make New Game</button></li>
-                                <li><button title="Downloads firmware for reformatting Thumby, follow the below steps &#10; 1. Turn on Thumby &#10; 2. Hold down bottom-left or down d-pad button &#10; 3. Turn Thumby back off while holding button, keep holding for 3s &#10; 4. Turn Thumby back on and release button &#10; 5. Download firmware .uf2 file by clicking this button &#10; 6. Drag .uf2 file to Thumby RP2040 volume using a file explorer &#10; 7. Press 'Format' in the filesystem widget" onclick="window.open('https://micropython.org/resources/firmware/rp2-pico-20220117-v1.18.uf2');" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Download Firmware</button></li>
+                                <li class="uk-nav-divider"></li>
+
                                 <li><button title="Resets all widget positions, refreshes page" id="IDResetLayoutBTN" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Reset Layout</button></li>
                                 <li><button title="Erases/closes all editors and bitmap builder then refreshes page" id="IDHardResetBTN" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Hard Reset Page</button></li>
                                 
+                                <li class="uk-nav-divider"></li>
                                 <li><button title="Toggles page theme between light and dark" id="IDInvertThemeBTN" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Invert Theme</button></li>
-
                                 <button id="editorThemeButton" title="Change the editor theme" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Editor Theme&#9662</button>
                                 <div uk-dropdown="offset: 0; mode: click">
                                     <ul id="EditorThemeUL" class="uk-nav uk-dropdown-nav" style="height: 200px; overflow: auto;">
                                     </ul>
                                 </div>
 
+                                <li class="uk-nav-divider"></li>
                                 <li><button title="Updates MicroPython" id="IDUpdateMicroPython" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Update MicroPython</button></li>
+                                <li><button title="Downloads firmware for reformatting Thumby, follow the below steps &#10; 1. Turn on Thumby &#10; 2. Hold down bottom-left or down d-pad button &#10; 3. Turn Thumby back off while holding button, keep holding for 3s &#10; 4. Turn Thumby back on and release button &#10; 5. Download firmware .uf2 file by clicking this button &#10; 6. Drag .uf2 file to Thumby RP2040 volume using a file explorer" onclick="window.open('https://github.com/TinyCircuits/TinyCircuits-Thumby-Code-Editor/raw/master/ThumbyFirmware.uf2');" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Download Firmware</button></li>
                                 <li class="uk-nav-divider"></li>
 
                                 <button title="Buttons for adding back any panel" class="uk-button uk-button-secondary uk-width-1-1 uk-height-1-1">Widgets&#9662</button>


### PR DESCRIPTION
What this does:

1. Changes the firmware download link in the utilities dropdown from 1.18.1 MicroPython (outdated) to the `ThumbyFirmware.uf2` in this repo.
2. Changes the look of the utilities dropdown to divide it into clearer sections (up to opinion of others):
![image](https://user-images.githubusercontent.com/50587838/213271984-aff0cdd0-a506-44ac-be7c-0ce8d4ed0d12.png)
