### PR TITLE
Disable/enable buttons in filesystem panel when Thumby is disconnected/connected

### DIFF
--- a/js/filesystem_wrapper.js
+++ b/js/filesystem_wrapper.js
@@ -153,6 +153,23 @@ class FILESYSTEM{
         });
 
         this.DIR_CHOOSER_PATH = "";
+
+        // Disable these buttons by default when no Thumby is connected (gets re-enabled in main.js on connection)
+        this.disableButtons();
+    }
+
+
+    disableButtons(){
+        this.FS_REFORMAT_BTN.disabled = true;
+        this.FS_UPDATE_LIBS_BTN.disabled = true;
+        this.FS_UPLOAD_BTN.disabled = true;
+    }
+
+
+    enableButtons(){
+        this.FS_REFORMAT_BTN.disabled = false;
+        this.FS_UPDATE_LIBS_BTN.disabled = false;
+        this.FS_UPLOAD_BTN.disabled = false;
     }
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -748,9 +748,13 @@ function registerShell(_container, state){
         ATERM.writeln("Waiting for connection... (click 'Connect Thumby')");
         FS.clearToWaiting();
         FS.removeUpdate();
+
+        FS.disableButtons();
     }
     REPL.onConnect = () => {
         ATERM.writeln('\x1b[1;32m' + "\n\rConnected" + '\x1b[1;0m');
+
+        FS.enableButtons();
     }
     REPL.onFSData = (jsonStrData, fsSizeData) => {
         FS.updateTree(jsonStrData);


### PR DESCRIPTION
Fixes #46 